### PR TITLE
Allow SSL credentials using default certificates

### DIFF
--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -419,16 +419,15 @@ main(int argc, char** argv)
   try {
     std::shared_ptr<grpc::ChannelCredentials> creds;
     if (FLAGS_ssl_cert.size() > 0 || FLAGS_use_ssl) {
-        LOG(INFO) << "Using Secure Server Credentials";
-        grpc::SslCredentialsOptions ssl_opts;
-        if (FLAGS_ssl_cert.size() > 0) {
-            LOG(INFO) << "Using SSL Credentials";
-            auto cacert = riva::utils::files::ReadFileContentAsString(FLAGS_ssl_cert);
-            ssl_opts.pem_root_certs = cacert;
-        }
-        creds = grpc::SslCredentials(ssl_opts);
-    }
-    else {
+      LOG(INFO) << "Using Secure Server Credentials";
+      grpc::SslCredentialsOptions ssl_opts;
+      if (FLAGS_ssl_cert.size() > 0) {
+        LOG(INFO) << "Using SSL Credentials";
+        auto cacert = riva::utils::files::ReadFileContentAsString(FLAGS_ssl_cert);
+        ssl_opts.pem_root_certs = cacert;
+      }
+      creds = grpc::SslCredentials(ssl_opts);
+    } else {
       LOG(INFO) << "Using Insecure Server Credentials";
       creds = grpc::InsecureChannelCredentials();
     }

--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -61,6 +61,8 @@ DEFINE_bool(
     "True returns text exactly as it was said with no normalization.  False applies text inverse "
     "normalization");
 DEFINE_string(ssl_cert, "", "Path to SSL client certificatates file");
+DEFINE_bool(use_ssl, false, "Whether to use SSL credentials or not. If ssl_cert is specified, "
+    "this is assumed to be true");
 DEFINE_bool(speaker_diarization, false, "Flag that controls if speaker diarization is requested");
 
 class RecognizeClient {
@@ -416,13 +418,17 @@ main(int argc, char** argv)
   std::shared_ptr<grpc::Channel> grpc_channel;
   try {
     std::shared_ptr<grpc::ChannelCredentials> creds;
-    if (FLAGS_ssl_cert.size() > 0) {
-      auto cacert = riva::utils::files::ReadFileContentAsString(FLAGS_ssl_cert);
-      grpc::SslCredentialsOptions ssl_opts;
-      ssl_opts.pem_root_certs = cacert;
-      LOG(INFO) << "Using SSL Credentials";
-      creds = grpc::SslCredentials(ssl_opts);
-    } else {
+    if (FLAGS_ssl_cert.size() > 0 || FLAGS_use_ssl) {
+        LOG(INFO) << "Using Secure Server Credentials";
+        grpc::SslCredentialsOptions ssl_opts;
+        if (FLAGS_ssl_cert.size() > 0) {
+            LOG(INFO) << "Using SSL Credentials";
+            auto cacert = riva::utils::files::ReadFileContentAsString(FLAGS_ssl_cert);
+            ssl_opts.pem_root_certs = cacert;
+        }
+        creds = grpc::SslCredentials(ssl_opts);
+    }
+    else {
       LOG(INFO) << "Using Insecure Server Credentials";
       creds = grpc::InsecureChannelCredentials();
     }

--- a/riva/clients/asr/riva_streaming_asr_client.cc
+++ b/riva/clients/asr/riva_streaming_asr_client.cc
@@ -147,16 +147,15 @@ main(int argc, char** argv)
   try {
     std::shared_ptr<grpc::ChannelCredentials> creds;
     if (FLAGS_ssl_cert.size() > 0 || FLAGS_use_ssl) {
-        LOG(INFO) << "Using Secure Server Credentials";
-        grpc::SslCredentialsOptions ssl_opts;
-        if (FLAGS_ssl_cert.size() > 0) {
-            LOG(INFO) << "Using SSL Credentials";
-            auto cacert = riva::utils::files::ReadFileContentAsString(FLAGS_ssl_cert);
-            ssl_opts.pem_root_certs = cacert;
-        }
-        creds = grpc::SslCredentials(ssl_opts);
-    }
-    else {
+      LOG(INFO) << "Using Secure Server Credentials";
+      grpc::SslCredentialsOptions ssl_opts;
+      if (FLAGS_ssl_cert.size() > 0) {
+        LOG(INFO) << "Using SSL Credentials";
+        auto cacert = riva::utils::files::ReadFileContentAsString(FLAGS_ssl_cert);
+        ssl_opts.pem_root_certs = cacert;
+      }
+      creds = grpc::SslCredentials(ssl_opts);
+    } else {
       LOG(INFO) << "Using Insecure Server Credentials";
       creds = grpc::InsecureChannelCredentials();
     }


### PR DESCRIPTION
gRPC allows authentication using SSL without explicitly passing an SSL certificate.
https://grpc.io/docs/guides/auth/#using-client-side-ssltls

This allows connecting to a public https service w/o passing a certificate client side.
The exception here is that on Windows there is no default client so an SSL cert must be passed.
A workaround is [here](https://stackoverflow.com/questions/71580681/ssl-grpc-client-works-fine-in-c-but-fails-with-unavailable-empty-update-in-c) but I don't think it's necessary to add given the target use case.
