### PR TITLE
Fix pre-commit isort, formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         args: ["--skip-string-normalization", "--line-length=119"]
         additional_dependencies: ['click==8.0.4']
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/riva/utils/opus/opus_client_decoder.h
+++ b/riva/utils/opus/opus_client_decoder.h
@@ -101,10 +101,10 @@ class Decoder {
   }
 
   /**
- * If requested rate is not supported this helper computes nearest supported one.
- * @param rate
- * @return
- */
+   * If requested rate is not supported this helper computes nearest supported one.
+   * @param rate
+   * @return
+   */
   static int32_t AdjustRateIfUnsupported(int32_t rate);
 
  private:


### PR DESCRIPTION
isort<5.12.0 apparently has a bug (see [this article](https://levelup.gitconnected.com/fix-runtimeerror-poetry-isort-5db7c67b60ff))
Bump isort and run `pre-commit run --all-files` to fix formatting everywhere.

@virajkarandikar requesting review please!

