### PR TITLE
asr: offline: fix print to file for empty transcript

### DIFF
--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -261,23 +261,23 @@ class RecognizeClient {
         double lat = std::chrono::duration<double, std::milli>(end_time - call->start_time).count();
         latencies_.push_back(lat);
 
+        Results output_result;
         if (call->response.results_size()) {
           const auto& last_result = call->response.results(call->response.results_size() - 1);
           total_audio_processed_ += last_result.audio_processed();
 
-          Results output_result;
           for (int r = 0; r < call->response.results_size(); ++r) {
             AppendResult(
                 output_result, call->response.results(r), word_time_offsets_, speaker_diarization_);
           }
-          if (print_transcripts_) {
-            PrintResult(
-                output_result, call->stream->wav->filename, word_time_offsets_,
-                speaker_diarization_);
-          }
-          if (!output_filename_.empty()) {
-            (this->*write_fn_)(output_result, call->stream->wav->filename);
-          }
+        }
+
+        if (print_transcripts_) {
+          PrintResult(
+              output_result, call->stream->wav->filename, word_time_offsets_, speaker_diarization_);
+        }
+        if (!output_filename_.empty()) {
+          (this->*write_fn_)(output_result, call->stream->wav->filename);
         }
       } else {
         std::cout << "RPC failed: " << call->status.error_message() << std::endl;


### PR DESCRIPTION
Printing to file was skipped in case of empty transcript.
