### PR TITLE
Copying NMT clients into client container after building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,7 @@ COPY --from=builder /opt/riva/clients/tts/riva_tts_perf_client /usr/local/bin/
 COPY --from=builder /opt/riva/clients/nlp/riva_nlp_classify_tokens /usr/local/bin/
 COPY --from=builder /opt/riva/clients/nlp/riva_nlp_punct /usr/local/bin/
 COPY --from=builder /opt/riva/clients/nlp/riva_nlp_qa /usr/local/bin/
+COPY --from=builder /opt/riva/clients/nmt/riva_nmt_t2t_client /usr/local/bin/
+COPY --from=builder /opt/riva/clients/nmt/riva_nmt_streaming_s2t_client /usr/local/bin/
+COPY --from=builder /opt/riva/clients/nmt/riva_nmt_streaming_s2s_client /usr/local/bin/
 COPY examples /work/examples


### PR DESCRIPTION
Copying nmt clients in to riva-client container 