### PR TITLE
Update NMT client to log latency

### DIFF
--- a/riva/clients/nmt/streaming_s2s_client.cc
+++ b/riva/clients/nmt/streaming_s2s_client.cc
@@ -272,7 +272,7 @@ StreamingS2SClient::PostProcessResults(std::shared_ptr<S2SClientCall> call, bool
     double lat =
         std::chrono::duration<double, std::milli>(call->recv_times[0] - call->send_times.back())
             .count();
-    std::cout << "Latency:" << lat << std::endl;
+    VLOG(1) << "Latency:" << lat << std::endl;
     latencies_.push_back(lat);
   }
 }

--- a/riva/clients/nmt/streaming_s2s_client.h
+++ b/riva/clients/nmt/streaming_s2s_client.h
@@ -82,13 +82,11 @@ class StreamingS2SClient {
 
   std::mutex latencies_mutex_;
 
-  bool print_latency_stats_;
-
  private:
   // Out of the passed in Channel comes the stub, stored here, our view of the
   // server's exposed services.
   std::unique_ptr<nr_nmt::RivaTranslation::Stub> stub_;
-  std::vector<double> int_latencies_, final_latencies_, latencies_;
+  std::vector<double> latencies_;
   std::string tts_encoding_;
   std::string tts_audio_file_;
   std::string tts_voice_name_;

--- a/riva/clients/nmt/streaming_s2t_client.cc
+++ b/riva/clients/nmt/streaming_s2t_client.cc
@@ -252,7 +252,7 @@ StreamingS2TClient::PostProcessResults(std::shared_ptr<S2TClientCall> call, bool
     double lat =
         std::chrono::duration<double, std::milli>(call->recv_times[0] - call->send_times.back())
             .count();
-    std::cout << "Latency:" << lat << std::endl;
+    VLOG(1)<< "Latency:" << lat << std::endl;
     latencies_.push_back(lat);
   }
 }

--- a/riva/clients/nmt/streaming_s2t_client.h
+++ b/riva/clients/nmt/streaming_s2t_client.h
@@ -81,13 +81,11 @@ class StreamingS2TClient {
 
   std::mutex latencies_mutex_;
 
-  bool print_latency_stats_;
-
  private:
   // Out of the passed in Channel comes the stub, stored here, our view of the
   // server's exposed services.
   std::unique_ptr<nr_nmt::RivaTranslation::Stub> stub_;
-  std::vector<double> int_latencies_, final_latencies_, latencies_;
+  std::vector<double> latencies_;
 
   std::string source_language_code_;
   std::string target_language_code_;


### PR DESCRIPTION
Adds changes needed to get latency for the s2s and s2t usecase, also cleans up unused variables.