### PR TITLE
perf: Add delay "async_delay_ms" within the Cpp client to trigger parallel requests asynchronously

### DIFF
--- a/riva/clients/asr/riva_streaming_asr_client.cc
+++ b/riva/clients/asr/riva_streaming_asr_client.cc
@@ -76,6 +76,7 @@ DEFINE_bool(
     "Whether to use SSL credentials or not. If ssl_cert is specified, "
     "this is assumed to be true");
 DEFINE_string(metadata, "", "Comma separated key-value pair(s) of metadata to be sent to server");
+DEFINE_int32(async_delay_ms, 0, "Delay to start parallel request asynchronously in milliseconds");
 
 void
 signal_handler(int signal_num)
@@ -118,6 +119,7 @@ main(int argc, char** argv)
   str_usage << "           --boosted_words_score=<float>" << std::endl;
   str_usage << "           --ssl_cert=<filename>" << std::endl;
   str_usage << "           --metadata=<key,value,...>" << std::endl;
+  str_usage << "           --async_delay_ms=<integer>" << std::endl;
   gflags::SetUsageMessage(str_usage.str());
   gflags::SetVersionString(::riva::utils::kBuildScmRevision);
 
@@ -164,7 +166,7 @@ main(int argc, char** argv)
       FLAGS_profanity_filter, FLAGS_word_time_offsets, FLAGS_automatic_punctuation,
       /* separate_recognition_per_channel*/ false, FLAGS_print_transcripts, FLAGS_chunk_duration_ms,
       FLAGS_interim_results, FLAGS_output_filename, FLAGS_model_name, FLAGS_simulate_realtime,
-      FLAGS_verbatim_transcripts, FLAGS_boosted_words_file, FLAGS_boosted_words_score);
+      FLAGS_verbatim_transcripts, FLAGS_boosted_words_file, FLAGS_boosted_words_score, FLAGS_async_delay_ms);
 
   if (FLAGS_audio_file.size()) {
     return recognize_client.DoStreamingFromFile(

--- a/riva/clients/asr/riva_streaming_asr_client.cc
+++ b/riva/clients/asr/riva_streaming_asr_client.cc
@@ -166,7 +166,8 @@ main(int argc, char** argv)
       FLAGS_profanity_filter, FLAGS_word_time_offsets, FLAGS_automatic_punctuation,
       /* separate_recognition_per_channel*/ false, FLAGS_print_transcripts, FLAGS_chunk_duration_ms,
       FLAGS_interim_results, FLAGS_output_filename, FLAGS_model_name, FLAGS_simulate_realtime,
-      FLAGS_verbatim_transcripts, FLAGS_boosted_words_file, FLAGS_boosted_words_score, FLAGS_async_delay_ms);
+      FLAGS_verbatim_transcripts, FLAGS_boosted_words_file, FLAGS_boosted_words_score,
+      FLAGS_async_delay_ms);
 
   if (FLAGS_audio_file.size()) {
     return recognize_client.DoStreamingFromFile(

--- a/riva/clients/asr/streaming_recognize_client.cc
+++ b/riva/clients/asr/streaming_recognize_client.cc
@@ -442,8 +442,6 @@ StreamingRecognizeClient::PrintLatencies(std::vector<double>& latencies, const s
     std::cout << "\t\tMedian\t\t90th\t\t95th\t\t99th\t\tAvg\n";
     std::cout << "\t\t" << median << "\t\t" << lat_90 << "\t\t" << lat_95 << "\t\t" << lat_99
               << "\t\t" << avg << std::endl;
- 
-  //std::cout << "MKJ-check build";
   }
 }
 

--- a/riva/clients/asr/streaming_recognize_client.cc
+++ b/riva/clients/asr/streaming_recognize_client.cc
@@ -197,7 +197,6 @@ int
 StreamingRecognizeClient::DoStreamingFromFile(
     std::string& audio_file, int32_t num_iterations, int32_t num_parallel_requests)
 {
-  std::cout << "check async_delay_ms is : " << async_delay_ms_;
   // Preload all wav files, sort by size to reduce tail effects
   std::vector<std::shared_ptr<WaveData>> all_wav;
   try {

--- a/riva/clients/asr/streaming_recognize_client.h
+++ b/riva/clients/asr/streaming_recognize_client.h
@@ -25,7 +25,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
-
+#include <random>
 #include "client_call.h"
 #include "riva/proto/riva_asr.grpc.pb.h"
 #include "riva/utils/thread_pool.h"
@@ -47,7 +47,7 @@ class StreamingRecognizeClient {
       bool print_transcripts, int32_t chunk_duration_ms, bool interim_results,
       std::string output_filename, std::string model_name, bool simulate_realtime,
       bool verbatim_transcripts, const std::string& boosted_phrases_file,
-      float boosted_phrases_score);
+      float boosted_phrases_score, int32_t async_delay_ms);
 
   ~StreamingRecognizeClient();
 
@@ -114,4 +114,5 @@ class StreamingRecognizeClient {
 
   std::vector<std::string> boosted_phrases_;
   float boosted_phrases_score_;
+  int32_t async_delay_ms_;
 };

--- a/riva/clients/asr/streaming_recognize_client_test.cc
+++ b/riva/clients/asr/streaming_recognize_client_test.cc
@@ -20,7 +20,7 @@ TEST(StreamingRecognizeClient, num_responses_requests)
 
   StreamingRecognizeClient recognize_client(
       grpc_channel, 1, "en-US", 1, false, false, false, false, false, 800, false, "dummy.txt",
-      "dummy", true, true, "", 10.);
+      "dummy", true, true, "", 10., 100);
 
   std::shared_ptr<ClientCall> call = std::make_shared<ClientCall>(1, true);
   uint32_t num_sends = 10;


### PR DESCRIPTION
Introduced a new parameter for the riva streaming asr client that allows asynchronous execution of parallel requests.

Example:
riva_streaming_asr_client --interim_results=false --chunk_duration_ms=160 --simulate_realtime=true --model_name=conformer-en-US-asr-streaming-asr-bls-ensemble --automatic_punctuation=true --num_parallel_requests=16 --num_iterations=48 --audio_file=/work/test_files/asr/wav/test/1272-135031-0000.wav **--async_delay_ms=100** --language_code=en-US --word_time_offsets=false --print_transcripts=false;