### PR TITLE
TTS: Add user dictionary parameter to tts-client

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,8 +69,8 @@ grpc_extra_deps()
 
 git_repository(
      name = "nvriva_common",
-     remote = "https://github.com/manishaj-nv/common.git",
-     commit = "bd3cace1d134913a88e0458a03dbf6aa6eb53b0f"
+     remote = "https://github.com/nvidia-riva/common.git",
+     commit = "988f86f84bf28d028f146ee5669b998ce3442be2"
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,8 +69,8 @@ grpc_extra_deps()
 
 git_repository(
      name = "nvriva_common",
-     remote = "https://github.com/nvidia-riva/common.git",
-     commit = "42bf472434054d4e30f06a2452b396c2a4486201"
+     remote = "https://github.com/manishaj-nv/common.git",
+     commit = "bd3cace1d134913a88e0458a03dbf6aa6eb53b0f"
 )
 
 http_archive(

--- a/riva/clients/tts/riva_tts_client.cc
+++ b/riva/clients/tts/riva_tts_client.cc
@@ -16,7 +16,6 @@
 #include <iomanip>
 #include <sstream>
 
-#include <boost/algorithm/string.hpp>
 #include "riva/clients/utils/grpc.h"
 #include "riva/proto/riva_tts.grpc.pb.h"
 #include "riva/utils/files/files.h"
@@ -63,28 +62,17 @@ ReadUserDictionaryFile(const std::string& dictionary_file)
 
     if (infile.is_open()) {
       std::string line;
-      bool is_first_line = true;
 
       while (std::getline(infile, line)) {
-        if (is_first_line) {
-          // Skip the first line it may contains headers
-          is_first_line = false;
-          continue;
-        }
-
         std::istringstream iss(line);
         std::string key, value;
 
         if (std::getline(iss, key, ' ') && std::getline(iss, value)) {
-          // Trim leading and trailing whitespace from key and value
-          boost::trim(key);
-          boost::trim(value);
-
           // Append the key-value pair to the dictionary string
           if (!dictionary_string.empty()) {
             dictionary_string += ",";
           }
-          dictionary_string += key + "  "  + value;
+          dictionary_string += key + "  " + value;
         }
       }
     } else {

--- a/riva/clients/tts/riva_tts_client.cc
+++ b/riva/clients/tts/riva_tts_client.cc
@@ -50,7 +50,7 @@ DEFINE_string(
     zero_shot_audio_prompt, "",
     "Input audio file for Zero Shot Model. Audio length between 0-3 seconds.");
 DEFINE_int32(zero_shot_quality, 20, "Required quality of output audio, ranges between 1-40.");
-DEFINE_string(user_dictionary, "", " User dictionary containing graph-to-phone custom words");
+DEFINE_string(custom_dictionary, "", " User dictionary containing graph-to-phone custom words");
 
 static const std::string LC_enUS = "en-US";
 
@@ -115,7 +115,7 @@ main(int argc, char** argv)
   str_usage << "           --metadata=<key,value,...>" << std::endl;
   str_usage << "           --zero_shot_audio_prompt=<filename>" << std::endl;
   str_usage << "           --zero_shot_quality=<quality>" << std::endl;
-  str_usage << "           --user_dictionary=<filename> " << std::endl;
+  str_usage << "           --custom_dictionary=<filename> " << std::endl;
   gflags::SetUsageMessage(str_usage.str());
   gflags::SetVersionString(::riva::utils::kBuildScmRevision);
 
@@ -178,8 +178,8 @@ main(int argc, char** argv)
     rate = riva::utils::opus::Decoder::AdjustRateIfUnsupported(FLAGS_rate);
   }
 
-  std::string user_dictionary = ReadUserDictionaryFile(FLAGS_user_dictionary);
-  request.set_user_dictionary(user_dictionary);
+  std::string custom_dictionary = ReadUserDictionaryFile(FLAGS_custom_dictionary);
+  request.set_custom_dictionary(custom_dictionary);
 
   request.set_sample_rate_hz(rate);
   request.set_voice_name(FLAGS_voice_name);

--- a/riva/clients/tts/riva_tts_client.cc
+++ b/riva/clients/tts/riva_tts_client.cc
@@ -13,8 +13,7 @@
 #include <iostream>
 #include <iterator>
 #include <string>
-#include <iomanip>
-#include <sstream>
+#include <regex>
 
 #include "riva/clients/utils/grpc.h"
 #include "riva/proto/riva_tts.grpc.pb.h"
@@ -64,15 +63,20 @@ ReadUserDictionaryFile(const std::string& dictionary_file)
       std::string line;
 
       while (std::getline(infile, line)) {
-        std::istringstream iss(line);
-        std::string key, value;
+        // Trim leading and trailing whitespaces
+        line = std::regex_replace(line, std::regex("^ +| +$"), "");
+        int pos = line.find("  ");
 
-        if (std::getline(iss, key, ' ') && std::getline(iss, value)) {
+        if (pos != std::string::npos) {
+          std::string key = line.substr(0, pos);
+          std::string value = std::regex_replace(line.substr(pos+2), std::regex("^ +"), "");
           // Append the key-value pair to the dictionary string
           if (!dictionary_string.empty()) {
             dictionary_string += ",";
           }
           dictionary_string += key + "  " + value;
+        } else {
+          LOG(WARNING) << "Warning: Malformed line " << line << std::endl;
         }
       }
     } else {

--- a/riva/clients/tts/riva_tts_perf_client.cc
+++ b/riva/clients/tts/riva_tts_perf_client.cc
@@ -7,8 +7,6 @@
 #include <glog/logging.h>
 #include <grpcpp/grpcpp.h>
 #include <strings.h>
-#include <iomanip>
-#include <sstream>
 
 #include <algorithm>
 #include <chrono>
@@ -19,6 +17,7 @@
 #include <string>
 #include <thread>
 #include <utility>
+#include <regex>
 
 #include "riva/clients/utils/grpc.h"
 #include "riva/proto/riva_tts.grpc.pb.h"
@@ -83,15 +82,20 @@ ReadUserDictionaryFile(const std::string& dictionary_file)
       std::string line;
 
       while (std::getline(infile, line)) {
-        std::istringstream iss(line);
-        std::string key, value;
+        // Trim leading and trailing whitespaces
+        line = std::regex_replace(line, std::regex("^ +| +$"), "");
+        int pos = line.find("  ");
 
-        if (std::getline(iss, key, ' ') && std::getline(iss, value)) {
+        if (pos != std::string::npos) {
+          std::string key = line.substr(0, pos);
+          std::string value = std::regex_replace(line.substr(pos+2), std::regex("^ +"), "");
           // Append the key-value pair to the dictionary string
           if (!dictionary_string.empty()) {
             dictionary_string += ",";
           }
           dictionary_string += key + "  " + value;
+        } else {
+          LOG(WARNING) << "Warning: Malformed line " << line << std::endl;
         }
       }
     } else {

--- a/riva/clients/tts/riva_tts_perf_client.cc
+++ b/riva/clients/tts/riva_tts_perf_client.cc
@@ -61,7 +61,7 @@ DEFINE_string(
     zero_shot_audio_prompt, "",
     "Input audio file for Zero Shot Model. Audio length between 0-3 seconds.");
 DEFINE_int32(zero_shot_quality, 20, "Required quality of output audio, ranges between 1-40.");
-DEFINE_string(user_dictionary, "", " User dictionary containing graph-to-phone custom words");
+DEFINE_string(custom_dictionary, "", " User dictionary containing graph-to-phone custom words");
 
 static const std::string LC_enUS = "en-US";
 
@@ -118,7 +118,7 @@ size_t
 synthesizeBatch(
     std::unique_ptr<nr_tts::RivaSpeechSynthesis::Stub> tts, std::string text, std::string language,
     uint32_t rate, std::string voice_name, std::string filepath,
-    std::string zero_shot_prompt_filename, int32_t zero_shot_quality, std::string user_dictionary)
+    std::string zero_shot_prompt_filename, int32_t zero_shot_quality, std::string custom_dictionary)
 {
   // Parse command line arguments.
   nr_tts::SynthesizeSpeechRequest request;
@@ -136,8 +136,8 @@ synthesizeBatch(
     return -1;
   }
 
-  user_dictionary = ReadUserDictionaryFile(user_dictionary);
-  request.set_user_dictionary(user_dictionary);
+  custom_dictionary = ReadUserDictionaryFile(custom_dictionary);
+  request.set_custom_dictionary(custom_dictionary);
 
   if (not zero_shot_prompt_filename.empty()) {
     auto zero_shot_data = request.mutable_zero_shot_data();
@@ -353,7 +353,7 @@ main(int argc, char** argv)
   str_usage << "           --metadata=<key,value,...>" << std::endl;
   str_usage << "           --zero_shot_audio_prompt=<filename>" << std::endl;
   str_usage << "           --zero_shot_quality=<quality>" << std::endl;
-  str_usage << "           --user_dictionary=<filename> " << std::endl;
+  str_usage << "           --custom_dictionary=<filename> " << std::endl;
 
   gflags::SetUsageMessage(str_usage.str());
   gflags::SetVersionString(::riva::utils::kBuildScmRevision);
@@ -551,7 +551,7 @@ main(int argc, char** argv)
           size_t num_samples = synthesizeBatch(
               std::move(tts), sentences[i][s].second, FLAGS_language, rate, FLAGS_voice_name,
               std::to_string(sentences[i][s].first) + ".wav", FLAGS_zero_shot_audio_prompt,
-              FLAGS_zero_shot_quality, FLAGS_user_dictionary);
+              FLAGS_zero_shot_quality, FLAGS_custom_dictionary);
           results_num_samples[i]->push_back(num_samples);
         }
       }));

--- a/riva/clients/tts/riva_tts_perf_client.cc
+++ b/riva/clients/tts/riva_tts_perf_client.cc
@@ -82,28 +82,17 @@ ReadUserDictionaryFile(const std::string& dictionary_file)
 
     if (infile.is_open()) {
       std::string line;
-      bool is_first_line = true;
 
       while (std::getline(infile, line)) {
-        if (is_first_line) {
-          // Skip the first line it may contains headers
-          is_first_line = false;
-          continue;
-        }
-
         std::istringstream iss(line);
         std::string key, value;
 
         if (std::getline(iss, key, ' ') && std::getline(iss, value)) {
-          // Trim leading and trailing whitespace from key and value
-          boost::trim(key);
-          boost::trim(value);
-
           // Append the key-value pair to the dictionary string
           if (!dictionary_string.empty()) {
             dictionary_string += ",";
           }
-          dictionary_string += key + "  "  + value;
+          dictionary_string += key + "  " + value;
         }
       }
     } else {

--- a/riva/clients/tts/riva_tts_perf_client.cc
+++ b/riva/clients/tts/riva_tts_perf_client.cc
@@ -10,7 +10,6 @@
 #include <iomanip>
 #include <sstream>
 
-#include <boost/algorithm/string.hpp>
 #include <algorithm>
 #include <chrono>
 #include <fstream>


### PR DESCRIPTION
This pull request introduces a addition of custom grapheme-to-phoneme dictionary for the Riva TTS client. The custom dictionary takes precedence over the default grapheme-to-phoneme rules and if a word is present in both the custom dictionary and the default rules, the custom mapping will be used.

Ensure custom handling of the dictionary is handled in the client end and is of the format key. 
Read textFile and pass as string of the format to the API "ARON  ˈdʒɑnsən,AARON  ˈdʒɑnsən"

**Usage**
To use, pass the --user_dictionary flag with the path to your dictionary file when running the riva_tts_client

Example:
riva_tts_client --voice_name=English-US.Female-1  --text=" Hi Aaron, this is speech synthesizer"  --audio_file=/opt/riva/riva-speech/output.wav --user_dictionary=<valid_dictionary_path>