### PR TITLE
Added configurable Start and End of Utterance parameters to ASR 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -70,7 +70,7 @@ grpc_extra_deps()
 git_repository(
      name = "nvriva_common",
      remote = "https://github.com/nvidia-riva/common.git",
-     commit = "2d2cc96597c8d30d3fd10f8f584e672efe5d2d10"
+     commit = "9dfc052bba9a0cc2cc4b4f156e0ca8a273e9444e"
 )
 
 http_archive(

--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -231,23 +231,18 @@ class RecognizeClient {
     if (start_history_ > 0) {
         endpointing_config->set_start_history(start_history_);
     }
-
     if (start_threshold_ > 0) {
         endpointing_config->set_start_threshold(start_threshold_);
     }
-
     if (stop_history_ > 0) {
         endpointing_config->set_stop_history(stop_history_);
     }
-
     if (stop_history_eou_ > 0) {
         endpointing_config->set_stop_history_eou(stop_history_eou_);
     }
-
     if (stop_threshold_ > 0) {
         endpointing_config->set_stop_threshold(stop_threshold_);
     }
-
     {
       std::lock_guard<std::mutex> lock(mutex_);
       curr_tasks_.emplace(stream->corr_id);

--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -440,7 +440,32 @@ main(int argc, char** argv)
     std::cerr << "max_alternatives must be greater than or equal to 1." << std::endl;
     return 1;
   }
-
+    
+  if( FLAGS_start_history < 0 && FLAGS_start_history != -1 ) {
+    std::cout << "start_history must be set to positive integer value" << std::endl;
+    return 1;
+  }
+  
+  if( FLAGS_start_threshold < 0 && FLAGS_start_threshold != -1 ) {
+    std::cout << "start_threshold must be set to positive value" << std::endl;
+    return 1;
+  }
+  
+  if( FLAGS_stop_history < 0 && FLAGS_stop_history != -1 ) {
+    std::cout << "stop_history must be set to positive value" << std::endl;
+    return 1;
+  }
+  
+  if( FLAGS_stop_history_eou < 0 && FLAGS_stop_history_eou != -1 ) {
+    std::cout << "stop_history_eou must be set to positive value" << std::endl;
+    return 1;
+  }
+  
+  if( FLAGS_stop_threshold < 0 && FLAGS_stop_threshold != -1 ) {
+    std::cout << "stop_threshold must be set to positive value" << std::endl;
+    return 1;
+  }
+  
   bool flag_set = gflags::GetCommandLineFlagInfoOrDie("riva_uri").is_default;
   const char* riva_uri = getenv("RIVA_URI");
 

--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -223,26 +223,10 @@ class RecognizeClient {
     speech_context->set_boost(boosted_phrases_score_);
 
     request.set_audio(&wav->data[0], wav->data.size());
-
-    // Set the endpoint parameters
-    // Get a mutable reference to the Endpointing config message
-    auto* endpointing_config = config->mutable_endpointing_config();
     
-    if (start_history_ > 0) {
-        endpointing_config->set_start_history(start_history_);
-    }
-    if (start_threshold_ > 0) {
-        endpointing_config->set_start_threshold(start_threshold_);
-    }
-    if (stop_history_ > 0) {
-        endpointing_config->set_stop_history(stop_history_);
-    }
-    if (stop_history_eou_ > 0) {
-        endpointing_config->set_stop_history_eou(stop_history_eou_);
-    }
-    if (stop_threshold_ > 0) {
-        endpointing_config->set_stop_threshold(stop_threshold_);
-    }
+    // Set the endpoint parameters
+    UpdateEndpointingConfig(config);
+   
     {
       std::lock_guard<std::mutex> lock(mutex_);
       curr_tasks_.emplace(stream->corr_id);
@@ -270,6 +254,32 @@ class RecognizeClient {
     call->response_reader->Finish(&call->response, &call->status, (void*)call);
   }
 
+  // Set the endpoint parameters
+  // Get a mutable reference to the Endpointing config message
+  void UpdateEndpointingConfig(nr_asr::RecognitionConfig* config)
+  {
+    if (!(start_history_ > 0 || start_threshold_ > 0 || stop_history_ > 0 || stop_history_eou_ > 0 || stop_threshold_ > 0)) {
+        return; 
+    }
+
+    auto* endpointing_config = config->mutable_endpointing_config();
+
+    if (start_history_ > 0) {
+        endpointing_config->set_start_history(start_history_);
+    }
+    if (start_threshold_ > 0) {
+        endpointing_config->set_start_threshold(start_threshold_);
+    }
+    if (stop_history_ > 0) {
+        endpointing_config->set_stop_history(stop_history_);
+    }
+    if (stop_history_eou_ > 0) {
+        endpointing_config->set_stop_history_eou(stop_history_eou_);
+    }
+    if (stop_threshold_ > 0) {
+        endpointing_config->set_stop_threshold(stop_threshold_);
+    }
+  }
   // Loop while listening for completed responses.
   // Prints out the response from the server.
   void AsyncCompleteRpc()

--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -67,11 +67,11 @@ DEFINE_bool(
     "this is assumed to be true");
 DEFINE_bool(speaker_diarization, false, "Flag that controls if speaker diarization is requested");
 DEFINE_string(metadata, "", "Comma separated key-value pair(s) of metadata to be sent to server");
-DEFINE_int32(start_history,0, "Value to detect and initiate start of speech utterance");
-DEFINE_double(start_threshold,0., "Threshold value to determine at what percentage start of speech is initiated");
-DEFINE_int32(stop_history,0, "Value to detect endpoint and reset decoder");
-DEFINE_int32(stop_history_eou,0, "Value to detect endpoint and generate an intermediate final transcript");
-DEFINE_double(stop_threshold,0., "Threshold value to determine when endpoint detected");
+DEFINE_int32(start_history,-1, "Value to detect and initiate start of speech utterance");
+DEFINE_double(start_threshold,-1., "Threshold value to determine at what percentage start of speech is initiated");
+DEFINE_int32(stop_history,-1, "Value to detect endpoint and reset decoder");
+DEFINE_int32(stop_history_eou,-1, "Value to detect endpoint and generate an intermediate final transcript");
+DEFINE_double(stop_threshold,-1., "Threshold value to determine when endpoint detected");
 
 class RecognizeClient {
  public:

--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -228,11 +228,25 @@ class RecognizeClient {
     // Get a mutable reference to the Endpointing config message
     auto* endpointing_config = config->mutable_endpointing_config();
     
-    endpointing_config->set_start_history(start_history_);
-    endpointing_config->set_start_threshold(start_threshold_);
-    endpointing_config->set_stop_history(stop_history_);
-    endpointing_config->set_stop_history_eou(stop_history_eou_);
-    endpointing_config->set_stop_threshold(stop_threshold_);
+    if (start_history_ > 0) {
+        endpointing_config->set_start_history(start_history_);
+    }
+
+    if (start_threshold_ > 0) {
+        endpointing_config->set_start_threshold(start_threshold_);
+    }
+
+    if (stop_history_ > 0) {
+        endpointing_config->set_stop_history(stop_history_);
+    }
+
+    if (stop_history_eou_ > 0) {
+        endpointing_config->set_stop_history_eou(stop_history_eou_);
+    }
+
+    if (stop_threshold_ > 0) {
+        endpointing_config->set_stop_threshold(stop_threshold_);
+    }
 
     {
       std::lock_guard<std::mutex> lock(mutex_);
@@ -438,31 +452,6 @@ main(int argc, char** argv)
 
   if (FLAGS_max_alternatives < 1) {
     std::cerr << "max_alternatives must be greater than or equal to 1." << std::endl;
-    return 1;
-  }
-    
-  if( FLAGS_start_history < 0 && FLAGS_start_history != -1 ) {
-    std::cout << "start_history must be set to positive integer value" << std::endl;
-    return 1;
-  }
-  
-  if( FLAGS_start_threshold < 0 && FLAGS_start_threshold != -1 ) {
-    std::cout << "start_threshold must be set to positive value" << std::endl;
-    return 1;
-  }
-  
-  if( FLAGS_stop_history < 0 && FLAGS_stop_history != -1 ) {
-    std::cout << "stop_history must be set to positive value" << std::endl;
-    return 1;
-  }
-  
-  if( FLAGS_stop_history_eou < 0 && FLAGS_stop_history_eou != -1 ) {
-    std::cout << "stop_history_eou must be set to positive value" << std::endl;
-    return 1;
-  }
-  
-  if( FLAGS_stop_threshold < 0 && FLAGS_stop_threshold != -1 ) {
-    std::cout << "stop_threshold must be set to positive value" << std::endl;
     return 1;
   }
   

--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -468,7 +468,7 @@ main(int argc, char** argv)
       FLAGS_model_name, FLAGS_output_ctm, FLAGS_verbatim_transcripts, FLAGS_boosted_words_file,
       (float)FLAGS_boosted_words_score, FLAGS_speaker_diarization, FLAGS_start_history, 
       FLAGS_start_threshold, FLAGS_stop_history, FLAGS_stop_history_eou,
-      FLAGS_stop_history_threshold);
+      FLAGS_stop_threshold);
 
   // Preload all wav files, sort by size to reduce tail effects
   std::vector<std::shared_ptr<WaveData>> all_wav;

--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -67,11 +67,11 @@ DEFINE_bool(
     "this is assumed to be true");
 DEFINE_bool(speaker_diarization, false, "Flag that controls if speaker diarization is requested");
 DEFINE_string(metadata, "", "Comma separated key-value pair(s) of metadata to be sent to server");
-DEFINE_int32(endpoint_start_history,0, "Value to detect and initiate start of speech utterance");
-DEFINE_double(endpoint_start_threshold,0., "Threshold value to determine at what percentage start of speech is initiated");
-DEFINE_int32(endpoint_reset_history,0, "Value to detect endpoint and reset decoder");
-DEFINE_int32(endpoint_response_history,0, "Value to detect endpoint and generate an intermediate final transcript");
-DEFINE_double(endpoint_stop_threshold,0., "Threshold value to determine when endpoint detected");
+DEFINE_int32(start_history,0, "Value to detect and initiate start of speech utterance");
+DEFINE_double(start_threshold,0., "Threshold value to determine at what percentage start of speech is initiated");
+DEFINE_int32(stop_history,0, "Value to detect endpoint and reset decoder");
+DEFINE_int32(stop_history_eou,0, "Value to detect endpoint and generate an intermediate final transcript");
+DEFINE_double(stop_threshold,0., "Threshold value to determine when endpoint detected");
 
 class RecognizeClient {
  public:
@@ -81,8 +81,8 @@ class RecognizeClient {
       bool automatic_punctuation, bool separate_recognition_per_channel, bool print_transcripts,
       std::string output_filename, std::string model_name, bool ctm, bool verbatim_transcripts,
       const std::string& boosted_phrases_file, float boosted_phrases_score,
-      bool speaker_diarization,int32_t endpoint_start_history, float endpoint_start_threshold, 
-      int32_t endpoint_reset_history, int32_t endpoint_response_history, float endpoint_stop_threshold)
+      bool speaker_diarization, int32_t start_history, float start_threshold, 
+      int32_t stop_history, int32_t stop_history_eou, float stop_threshold)
       : stub_(nr_asr::RivaSpeechRecognition::NewStub(channel)), language_code_(language_code),
         max_alternatives_(max_alternatives), profanity_filter_(profanity_filter),
         word_time_offsets_(word_time_offsets), automatic_punctuation_(automatic_punctuation),
@@ -91,9 +91,9 @@ class RecognizeClient {
         done_sending_(false), num_requests_(0), num_responses_(0), num_failed_requests_(0),
         total_audio_processed_(0.), model_name_(model_name), output_filename_(output_filename),
         verbatim_transcripts_(verbatim_transcripts), boosted_phrases_score_(boosted_phrases_score), 
-        endpoint_start_history_(endpoint_start_history), endpoint_start_threshold_(endpoint_start_threshold),
-        endpoint_reset_history_(endpoint_reset_history), endpoint_response_history_(endpoint_response_history), 
-        endpoint_stop_threshold_(endpoint_stop_threshold)
+        start_history_(start_history), start_threshold_(start_threshold),
+        stop_history_(stop_history), stop_history_eou_(stop_history_eou), 
+        stop_threshold_(stop_threshold)
   {
     if (!output_filename.empty()) {
       output_file_.open(output_filename);
@@ -228,11 +228,11 @@ class RecognizeClient {
     // Get a mutable reference to the EOUConfig message
     auto* eou_config = config->mutable_eou_config();
     
-    eou_config->set_endpoint_start_history(endpoint_start_history_);
-    eou_config->set_endpoint_start_threshold(endpoint_start_threshold_);
-    eou_config->set_endpoint_reset_history(endpoint_reset_history_);
-    eou_config->set_endpoint_response_history(endpoint_response_history_);
-    eou_config->set_endpoint_stop_threshold(endpoint_stop_threshold_);
+    eou_config->set_start_history(start_history_);
+    eou_config->set_start_threshold(start_threshold_);
+    eou_config->set_stop_history(stop_history_);
+    eou_config->set_stop_history_eou(stop_history_eou_);
+    eou_config->set_stop_threshold(stop_threshold_);
 
     {
       std::lock_guard<std::mutex> lock(mutex_);
@@ -383,11 +383,11 @@ class RecognizeClient {
   float boosted_phrases_score_;
   void (RecognizeClient::*write_fn_)(const Results& result, const std::string& filename);
 
-  int32_t endpoint_start_history_;
-  float endpoint_start_threshold_;
-  int32_t endpoint_reset_history_;
-  int32_t endpoint_response_history_;
-  float endpoint_stop_threshold_;
+  int32_t start_history_;
+  float start_threshold_;
+  int32_t stop_history_;
+  int32_t stop_history_eou_;
+  float stop_threshold_;
 };
 
 int
@@ -416,11 +416,11 @@ main(int argc, char** argv)
   str_usage << "           --ssl_cert=<filename>" << std::endl;
   str_usage << "           --speaker_diarization=<true|false>" << std::endl;
   str_usage << "           --metadata=<key,value,...>" << std::endl;
-  str_usage << "           --endpoint_start_history=<int>" << std::endl;
-  str_usage << "           --endpoint_start_threshold=<float>" << std::endl;
-  str_usage << "           --endpoint_reset_history=<int>" << std::endl;
-  str_usage << "           --endpoint_response_history=<int>" << std::endl;
-  str_usage << "           --endpoint_stop_threshold=<float>" <<  std::endl;
+  str_usage << "           --start_history=<int>" << std::endl;
+  str_usage << "           --start_threshold=<float>" << std::endl;
+  str_usage << "           --stop_history=<int>" << std::endl;
+  str_usage << "           --stop_history_eou=<int>" << std::endl;
+  str_usage << "           --stop_threshold=<float>" <<  std::endl;
   gflags::SetUsageMessage(str_usage.str());
   gflags::SetVersionString(::riva::utils::kBuildScmRevision);
 
@@ -466,9 +466,9 @@ main(int argc, char** argv)
       FLAGS_word_time_offsets, FLAGS_automatic_punctuation,
       /* separate_recognition_per_channel*/ false, FLAGS_print_transcripts, FLAGS_output_filename,
       FLAGS_model_name, FLAGS_output_ctm, FLAGS_verbatim_transcripts, FLAGS_boosted_words_file,
-      (float)FLAGS_boosted_words_score, FLAGS_speaker_diarization, FLAGS_endpoint_start_history, 
-      FLAGS_endpoint_start_threshold, FLAGS_endpoint_reset_history, FLAGS_endpoint_response_history,
-      FLAGS_endpoint_stop_threshold);
+      (float)FLAGS_boosted_words_score, FLAGS_speaker_diarization, FLAGS_start_history, 
+      FLAGS_start_threshold, FLAGS_stop_history, FLAGS_stop_history_eou,
+      FLAGS_stop_history_threshold);
 
   // Preload all wav files, sort by size to reduce tail effects
   std::vector<std::shared_ptr<WaveData>> all_wav;

--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -225,14 +225,14 @@ class RecognizeClient {
     request.set_audio(&wav->data[0], wav->data.size());
 
     // Set the endpoint parameters
-    // Get a mutable reference to the EOUConfig message
-    auto* eou_config = config->mutable_eou_config();
+    // Get a mutable reference to the Endpointing config message
+    auto* endpointing_config = config->mutable_endpointing_config();
     
-    eou_config->set_start_history(start_history_);
-    eou_config->set_start_threshold(start_threshold_);
-    eou_config->set_stop_history(stop_history_);
-    eou_config->set_stop_history_eou(stop_history_eou_);
-    eou_config->set_stop_threshold(stop_threshold_);
+    endpointing_config->set_start_history(start_history_);
+    endpointing_config->set_start_threshold(start_threshold_);
+    endpointing_config->set_stop_history(stop_history_);
+    endpointing_config->set_stop_history_eou(stop_history_eou_);
+    endpointing_config->set_stop_threshold(stop_threshold_);
 
     {
       std::lock_guard<std::mutex> lock(mutex_);

--- a/riva/clients/asr/riva_streaming_asr_client.cc
+++ b/riva/clients/asr/riva_streaming_asr_client.cc
@@ -76,11 +76,11 @@ DEFINE_bool(
     "Whether to use SSL credentials or not. If ssl_cert is specified, "
     "this is assumed to be true");
 DEFINE_string(metadata, "", "Comma separated key-value pair(s) of metadata to be sent to server");
-DEFINE_int32(start_history,0, "Value to detect and initiate start of speech utterance");
-DEFINE_double(start_threshold,0., "Threshold value to determine at what percentage start of speech is initiated");
-DEFINE_int32(stop_history,0, "Value to detect endpoint and reset decoder");
-DEFINE_int32(stop_history_eou,0, "Value to detect endpoint and generate an intermediate final transcript");
-DEFINE_double(stop_threshold,0., "Threshold value to determine when endpoint detected");
+DEFINE_int32(start_history,-1, "Value to detect and initiate start of speech utterance");
+DEFINE_double(start_threshold,-1., "Threshold value to determine at what percentage start of speech is initiated");
+DEFINE_int32(stop_history,-1, "Value to detect endpoint and reset decoder");
+DEFINE_int32(stop_history_eou,-1, "Value to detect endpoint and generate an intermediate final transcript");
+DEFINE_double(stop_threshold,-1., "Threshold value to determine when endpoint detected");
 
 void
 signal_handler(int signal_num)
@@ -146,6 +146,31 @@ main(int argc, char** argv)
 
   if (FLAGS_max_alternatives < 1) {
     std::cerr << "max_alternatives must be greater than or equal to 1." << std::endl;
+    return 1;
+  }
+
+  if( FLAGS_start_history <= 0 && FLAGS_start_history != -1 ) {
+    std::cout << "start_history must be set positive value" << std::endl;
+    return 1;
+  }
+  
+  if( FLAGS_start_threshold <= 0 && FLAGS_start_threshold != -1 ) {
+    std::cout << "start_threshold must be set positive value" << std::endl;
+    return 1;
+  }
+  
+  if( FLAGS_stop_history <= 0 && FLAGS_stop_history != -1 ) {
+    std::cout << "stop_history must be set positive value" << std::endl;
+    return 1;
+  }
+  
+  if( FLAGS_stop_history_eou <= 0 && FLAGS_stop_history_eou != -1 ) {
+    std::cout << "stop_history_eou must be set positive value" << std::endl;
+    return 1;
+  }
+  
+  if( FLAGS_stop_threshold <= 0 && FLAGS_stop_threshold != -1 ) {
+    std::cout << "stop_threshold must be set positive value" << std::endl;
     return 1;
   }
 

--- a/riva/clients/asr/riva_streaming_asr_client.cc
+++ b/riva/clients/asr/riva_streaming_asr_client.cc
@@ -76,6 +76,11 @@ DEFINE_bool(
     "Whether to use SSL credentials or not. If ssl_cert is specified, "
     "this is assumed to be true");
 DEFINE_string(metadata, "", "Comma separated key-value pair(s) of metadata to be sent to server");
+DEFINE_int32(endpoint_start_history,0, "Value to detect and initiate start of speech utterance");
+DEFINE_double(endpoint_start_threshold,0., "Threshold value to determine at what percentage start of speech is initiated");
+DEFINE_int32(endpoint_reset_history,0, "Value to detect endpoint and reset decoder");
+DEFINE_int32(endpoint_response_history,0, "Value to detect endpoint and generate an intermediate final transcript");
+DEFINE_double(endpoint_stop_threshold,0., "Threshold value to determine when endpoint detected");
 
 void
 signal_handler(int signal_num)
@@ -118,6 +123,11 @@ main(int argc, char** argv)
   str_usage << "           --boosted_words_score=<float>" << std::endl;
   str_usage << "           --ssl_cert=<filename>" << std::endl;
   str_usage << "           --metadata=<key,value,...>" << std::endl;
+  str_usage << "           --endpoint_start_history=<int>" << std::endl;
+  str_usage << "           --endpoint_start_threshold=<double>" << std::endl;
+  str_usage << "           --endpoint_reset_history=<int>" << std::endl;
+  str_usage << "           --endpoint_response_history=<int>" << std::endl;
+  str_usage << "           --endpointStopThreshold=<double>" <<  std::endl;
   gflags::SetUsageMessage(str_usage.str());
   gflags::SetVersionString(::riva::utils::kBuildScmRevision);
 
@@ -164,7 +174,9 @@ main(int argc, char** argv)
       FLAGS_profanity_filter, FLAGS_word_time_offsets, FLAGS_automatic_punctuation,
       /* separate_recognition_per_channel*/ false, FLAGS_print_transcripts, FLAGS_chunk_duration_ms,
       FLAGS_interim_results, FLAGS_output_filename, FLAGS_model_name, FLAGS_simulate_realtime,
-      FLAGS_verbatim_transcripts, FLAGS_boosted_words_file, FLAGS_boosted_words_score);
+      FLAGS_verbatim_transcripts, FLAGS_boosted_words_file, FLAGS_boosted_words_score, 
+      FLAGS_endpoint_start_history, FLAGS_endpoint_start_threshold, FLAGS_endpoint_reset_history, 
+      FLAGS_endpoint_response_history, FLAGS_endpoint_stop_threshold);
 
   if (FLAGS_audio_file.size()) {
     return recognize_client.DoStreamingFromFile(

--- a/riva/clients/asr/riva_streaming_asr_client.cc
+++ b/riva/clients/asr/riva_streaming_asr_client.cc
@@ -124,10 +124,10 @@ main(int argc, char** argv)
   str_usage << "           --ssl_cert=<filename>" << std::endl;
   str_usage << "           --metadata=<key,value,...>" << std::endl;
   str_usage << "           --endpoint_start_history=<int>" << std::endl;
-  str_usage << "           --endpoint_start_threshold=<double>" << std::endl;
+  str_usage << "           --endpoint_start_threshold=<float>" << std::endl;
   str_usage << "           --endpoint_reset_history=<int>" << std::endl;
   str_usage << "           --endpoint_response_history=<int>" << std::endl;
-  str_usage << "           --endpointStopThreshold=<double>" <<  std::endl;
+  str_usage << "           --endpoint_stop_threshold=<float>" <<  std::endl;
   gflags::SetUsageMessage(str_usage.str());
   gflags::SetVersionString(::riva::utils::kBuildScmRevision);
 

--- a/riva/clients/asr/riva_streaming_asr_client.cc
+++ b/riva/clients/asr/riva_streaming_asr_client.cc
@@ -76,11 +76,11 @@ DEFINE_bool(
     "Whether to use SSL credentials or not. If ssl_cert is specified, "
     "this is assumed to be true");
 DEFINE_string(metadata, "", "Comma separated key-value pair(s) of metadata to be sent to server");
-DEFINE_int32(endpoint_start_history,0, "Value to detect and initiate start of speech utterance");
-DEFINE_double(endpoint_start_threshold,0., "Threshold value to determine at what percentage start of speech is initiated");
-DEFINE_int32(endpoint_reset_history,0, "Value to detect endpoint and reset decoder");
-DEFINE_int32(endpoint_response_history,0, "Value to detect endpoint and generate an intermediate final transcript");
-DEFINE_double(endpoint_stop_threshold,0., "Threshold value to determine when endpoint detected");
+DEFINE_int32(start_history,0, "Value to detect and initiate start of speech utterance");
+DEFINE_double(start_threshold,0., "Threshold value to determine at what percentage start of speech is initiated");
+DEFINE_int32(stop_history,0, "Value to detect endpoint and reset decoder");
+DEFINE_int32(stop_history_eou,0, "Value to detect endpoint and generate an intermediate final transcript");
+DEFINE_double(stop_threshold,0., "Threshold value to determine when endpoint detected");
 
 void
 signal_handler(int signal_num)
@@ -123,11 +123,11 @@ main(int argc, char** argv)
   str_usage << "           --boosted_words_score=<float>" << std::endl;
   str_usage << "           --ssl_cert=<filename>" << std::endl;
   str_usage << "           --metadata=<key,value,...>" << std::endl;
-  str_usage << "           --endpoint_start_history=<int>" << std::endl;
-  str_usage << "           --endpoint_start_threshold=<float>" << std::endl;
-  str_usage << "           --endpoint_reset_history=<int>" << std::endl;
-  str_usage << "           --endpoint_response_history=<int>" << std::endl;
-  str_usage << "           --endpoint_stop_threshold=<float>" <<  std::endl;
+  str_usage << "           --start_history=<int>" << std::endl;
+  str_usage << "           --start_threshold=<float>" << std::endl;
+  str_usage << "           --stop_history=<int>" << std::endl;
+  str_usage << "           --stop_history_eou=<int>" << std::endl;
+  str_usage << "           --stop_threshold=<float>" <<  std::endl;
   gflags::SetUsageMessage(str_usage.str());
   gflags::SetVersionString(::riva::utils::kBuildScmRevision);
 
@@ -175,8 +175,8 @@ main(int argc, char** argv)
       /* separate_recognition_per_channel*/ false, FLAGS_print_transcripts, FLAGS_chunk_duration_ms,
       FLAGS_interim_results, FLAGS_output_filename, FLAGS_model_name, FLAGS_simulate_realtime,
       FLAGS_verbatim_transcripts, FLAGS_boosted_words_file, FLAGS_boosted_words_score, 
-      FLAGS_endpoint_start_history, FLAGS_endpoint_start_threshold, FLAGS_endpoint_reset_history, 
-      FLAGS_endpoint_response_history, FLAGS_endpoint_stop_threshold);
+      FLAGS_start_history, FLAGS_start_threshold, FLAGS_stop_history, 
+      FLAGS_stop_history_eou, FLAGS_stop_threshold);
 
   if (FLAGS_audio_file.size()) {
     return recognize_client.DoStreamingFromFile(

--- a/riva/clients/asr/riva_streaming_asr_client.cc
+++ b/riva/clients/asr/riva_streaming_asr_client.cc
@@ -149,31 +149,6 @@ main(int argc, char** argv)
     return 1;
   }
 
-  if( FLAGS_start_history <= 0 && FLAGS_start_history != -1 ) {
-    std::cout << "start_history must be set positive value" << std::endl;
-    return 1;
-  }
-  
-  if( FLAGS_start_threshold <= 0 && FLAGS_start_threshold != -1 ) {
-    std::cout << "start_threshold must be set positive value" << std::endl;
-    return 1;
-  }
-  
-  if( FLAGS_stop_history <= 0 && FLAGS_stop_history != -1 ) {
-    std::cout << "stop_history must be set positive value" << std::endl;
-    return 1;
-  }
-  
-  if( FLAGS_stop_history_eou <= 0 && FLAGS_stop_history_eou != -1 ) {
-    std::cout << "stop_history_eou must be set positive value" << std::endl;
-    return 1;
-  }
-  
-  if( FLAGS_stop_threshold <= 0 && FLAGS_stop_threshold != -1 ) {
-    std::cout << "stop_threshold must be set positive value" << std::endl;
-    return 1;
-  }
-
   bool flag_set = gflags::GetCommandLineFlagInfoOrDie("riva_uri").is_default;
   const char* riva_uri = getenv("RIVA_URI");
 

--- a/riva/clients/asr/streaming_recognize_client.cc
+++ b/riva/clients/asr/streaming_recognize_client.cc
@@ -58,8 +58,8 @@ StreamingRecognizeClient::StreamingRecognizeClient(
     bool print_transcripts, int32_t chunk_duration_ms, bool interim_results,
     std::string output_filename, std::string model_name, bool simulate_realtime,
     bool verbatim_transcripts, const std::string& boosted_phrases_file, float boosted_phrases_score,
-    int32_t endpoint_start_history, float endpoint_start_threshold, int32_t endpoint_reset_history, 
-    int32_t endpoint_response_history, float endpoint_stop_threshold)
+    int32_t start_history, float start_threshold, int32_t stop_history, 
+    int32_t stop_history_eou, float stop_threshold)
     : print_latency_stats_(true), stub_(nr_asr::RivaSpeechRecognition::NewStub(channel)),
       language_code_(language_code), max_alternatives_(max_alternatives),
       profanity_filter_(profanity_filter), word_time_offsets_(word_time_offsets),
@@ -69,9 +69,9 @@ StreamingRecognizeClient::StreamingRecognizeClient(
       interim_results_(interim_results), total_audio_processed_(0.), num_streams_started_(0),
       model_name_(model_name), simulate_realtime_(simulate_realtime),
       verbatim_transcripts_(verbatim_transcripts), boosted_phrases_score_(boosted_phrases_score),
-      endpoint_start_history_(endpoint_start_history), endpoint_start_threshold_(endpoint_start_threshold),
-      endpoint_reset_history_(endpoint_reset_history), endpoint_response_history_(endpoint_response_history), 
-      endpoint_stop_threshold_(endpoint_stop_threshold)
+      start_history_(start_history), start_threshold_(start_threshold),
+      stop_history_(stop_history), stop_history_eou_(stop_history), 
+      stop_threshold_(stop_threshold)
 {
   num_active_streams_.store(0);
   num_streams_finished_.store(0);
@@ -148,11 +148,11 @@ StreamingRecognizeClient::GenerateRequests(std::shared_ptr<ClientCall> call)
       // Get a mutable reference to the EOUConfig message
       auto* eou_config = config->mutable_eou_config();
       
-      eou_config->set_endpoint_start_history(endpoint_start_history_);
-      eou_config->set_endpoint_start_threshold(endpoint_start_threshold_);
-      eou_config->set_endpoint_reset_history(endpoint_reset_history_);
-      eou_config->set_endpoint_response_history(endpoint_response_history_);
-      eou_config->set_endpoint_stop_threshold(endpoint_stop_threshold_);
+      eou_config->set_start_history(start_history_);
+      eou_config->set_start_threshold(start_threshold_);
+      eou_config->set_stop_history(stop_history_);
+      eou_config->set_stop_history_eou(stop_history_eou_);
+      eou_config->set_stop_threshold(stop_threshold_);
 
       call->streamer->Write(request);
       first_write = false;

--- a/riva/clients/asr/streaming_recognize_client.cc
+++ b/riva/clients/asr/streaming_recognize_client.cc
@@ -147,12 +147,26 @@ StreamingRecognizeClient::GenerateRequests(std::shared_ptr<ClientCall> call)
       // Set the endpoint parameters
       // Get a mutable reference to the Endpointing config message
       auto* endpointing_config = config->mutable_endpointing_config();
-      
-      endpointing_config->set_start_history(start_history_);
-      endpointing_config->set_start_threshold(start_threshold_);
-      endpointing_config->set_stop_history(stop_history_);
-      endpointing_config->set_stop_history_eou(stop_history_eou_);
-      endpointing_config->set_stop_threshold(stop_threshold_);
+        
+      if (start_history_ > 0) {
+          endpointing_config->set_start_history(start_history_);
+      }
+
+      if (start_threshold_ > 0) {
+          endpointing_config->set_start_threshold(start_threshold_);
+      }
+
+      if (stop_history_ > 0) {
+          endpointing_config->set_stop_history(stop_history_);
+      }
+
+      if (stop_history_eou_ > 0) {
+          endpointing_config->set_stop_history_eou(stop_history_eou_);
+      }
+
+      if (stop_threshold_ > 0) {
+          endpointing_config->set_stop_threshold(stop_threshold_);
+      }
 
       call->streamer->Write(request);
       first_write = false;

--- a/riva/clients/asr/streaming_recognize_client.cc
+++ b/riva/clients/asr/streaming_recognize_client.cc
@@ -57,7 +57,9 @@ StreamingRecognizeClient::StreamingRecognizeClient(
     bool word_time_offsets, bool automatic_punctuation, bool separate_recognition_per_channel,
     bool print_transcripts, int32_t chunk_duration_ms, bool interim_results,
     std::string output_filename, std::string model_name, bool simulate_realtime,
-    bool verbatim_transcripts, const std::string& boosted_phrases_file, float boosted_phrases_score)
+    bool verbatim_transcripts, const std::string& boosted_phrases_file, float boosted_phrases_score,
+    int32_t endpoint_start_history, float endpoint_start_threshold, int32_t endpoint_reset_history, 
+    int32_t endpoint_response_history, float endpoint_stop_threshold)
     : print_latency_stats_(true), stub_(nr_asr::RivaSpeechRecognition::NewStub(channel)),
       language_code_(language_code), max_alternatives_(max_alternatives),
       profanity_filter_(profanity_filter), word_time_offsets_(word_time_offsets),
@@ -66,7 +68,10 @@ StreamingRecognizeClient::StreamingRecognizeClient(
       print_transcripts_(print_transcripts), chunk_duration_ms_(chunk_duration_ms),
       interim_results_(interim_results), total_audio_processed_(0.), num_streams_started_(0),
       model_name_(model_name), simulate_realtime_(simulate_realtime),
-      verbatim_transcripts_(verbatim_transcripts), boosted_phrases_score_(boosted_phrases_score)
+      verbatim_transcripts_(verbatim_transcripts), boosted_phrases_score_(boosted_phrases_score),
+      endpoint_start_history_(endpoint_start_history), endpoint_start_threshold_(endpoint_start_threshold),
+      endpoint_reset_history_(endpoint_reset_history), endpoint_response_history_(endpoint_response_history), 
+      endpoint_stop_threshold_(endpoint_stop_threshold)
 {
   num_active_streams_.store(0);
   num_streams_finished_.store(0);
@@ -138,6 +143,16 @@ StreamingRecognizeClient::GenerateRequests(std::shared_ptr<ClientCall> call)
       nr_asr::SpeechContext* speech_context = config->add_speech_contexts();
       *(speech_context->mutable_phrases()) = {boosted_phrases_.begin(), boosted_phrases_.end()};
       speech_context->set_boost(boosted_phrases_score_);
+
+      // Set the endpoint parameters
+      // Get a mutable reference to the EOUConfig message
+      auto* eou_config = config->mutable_eou_config();
+      
+      eou_config->set_endpoint_start_history(endpoint_start_history_);
+      eou_config->set_endpoint_start_threshold(endpoint_start_threshold_);
+      eou_config->set_endpoint_reset_history(endpoint_reset_history_);
+      eou_config->set_endpoint_response_history(endpoint_response_history_);
+      eou_config->set_endpoint_stop_threshold(endpoint_stop_threshold_);
 
       call->streamer->Write(request);
       first_write = false;

--- a/riva/clients/asr/streaming_recognize_client.cc
+++ b/riva/clients/asr/streaming_recognize_client.cc
@@ -151,19 +151,15 @@ StreamingRecognizeClient::GenerateRequests(std::shared_ptr<ClientCall> call)
       if (start_history_ > 0) {
           endpointing_config->set_start_history(start_history_);
       }
-
       if (start_threshold_ > 0) {
           endpointing_config->set_start_threshold(start_threshold_);
       }
-
       if (stop_history_ > 0) {
           endpointing_config->set_stop_history(stop_history_);
       }
-
       if (stop_history_eou_ > 0) {
           endpointing_config->set_stop_history_eou(stop_history_eou_);
       }
-
       if (stop_threshold_ > 0) {
           endpointing_config->set_stop_threshold(stop_threshold_);
       }

--- a/riva/clients/asr/streaming_recognize_client.cc
+++ b/riva/clients/asr/streaming_recognize_client.cc
@@ -111,6 +111,33 @@ StreamingRecognizeClient::StartNewStream(std::unique_ptr<Stream> stream)
 }
 
 void
+StreamingRecognizeClient::UpdateEndpointingConfig(nr_asr::RecognitionConfig* config)
+{
+  if (!(start_history_ > 0 || start_threshold_ > 0 || stop_history_ > 0 || stop_history_eou_ > 0 || stop_threshold_ > 0)) {
+      return; 
+  }
+  // Set the endpoint parameters
+  // Get a mutable reference to the Endpointing config message
+  auto* endpointing_config = config->mutable_endpointing_config();
+
+  if (start_history_ > 0) {
+      endpointing_config->set_start_history(start_history_);
+  }
+  if (start_threshold_ > 0) {
+      endpointing_config->set_start_threshold(start_threshold_);
+  }
+  if (stop_history_ > 0) {
+      endpointing_config->set_stop_history(stop_history_);
+  }
+  if (stop_history_eou_ > 0) {
+      endpointing_config->set_stop_history_eou(stop_history_eou_);
+  }
+  if (stop_threshold_ > 0) {
+      endpointing_config->set_stop_threshold(stop_threshold_);
+  }
+}
+
+void
 StreamingRecognizeClient::GenerateRequests(std::shared_ptr<ClientCall> call)
 {
   float audio_processed = 0.;
@@ -145,24 +172,7 @@ StreamingRecognizeClient::GenerateRequests(std::shared_ptr<ClientCall> call)
       speech_context->set_boost(boosted_phrases_score_);
 
       // Set the endpoint parameters
-      // Get a mutable reference to the Endpointing config message
-      auto* endpointing_config = config->mutable_endpointing_config();
-        
-      if (start_history_ > 0) {
-          endpointing_config->set_start_history(start_history_);
-      }
-      if (start_threshold_ > 0) {
-          endpointing_config->set_start_threshold(start_threshold_);
-      }
-      if (stop_history_ > 0) {
-          endpointing_config->set_stop_history(stop_history_);
-      }
-      if (stop_history_eou_ > 0) {
-          endpointing_config->set_stop_history_eou(stop_history_eou_);
-      }
-      if (stop_threshold_ > 0) {
-          endpointing_config->set_stop_threshold(stop_threshold_);
-      }
+      UpdateEndpointingConfig(config);
 
       call->streamer->Write(request);
       first_write = false;

--- a/riva/clients/asr/streaming_recognize_client.cc
+++ b/riva/clients/asr/streaming_recognize_client.cc
@@ -145,14 +145,14 @@ StreamingRecognizeClient::GenerateRequests(std::shared_ptr<ClientCall> call)
       speech_context->set_boost(boosted_phrases_score_);
 
       // Set the endpoint parameters
-      // Get a mutable reference to the EOUConfig message
-      auto* eou_config = config->mutable_eou_config();
+      // Get a mutable reference to the Endpointing config message
+      auto* endpointing_config = config->mutable_endpointing_config();
       
-      eou_config->set_start_history(start_history_);
-      eou_config->set_start_threshold(start_threshold_);
-      eou_config->set_stop_history(stop_history_);
-      eou_config->set_stop_history_eou(stop_history_eou_);
-      eou_config->set_stop_threshold(stop_threshold_);
+      endpointing_config->set_start_history(start_history_);
+      endpointing_config->set_start_threshold(start_threshold_);
+      endpointing_config->set_stop_history(stop_history_);
+      endpointing_config->set_stop_history_eou(stop_history_eou_);
+      endpointing_config->set_stop_threshold(stop_threshold_);
 
       call->streamer->Write(request);
       first_write = false;

--- a/riva/clients/asr/streaming_recognize_client.h
+++ b/riva/clients/asr/streaming_recognize_client.h
@@ -47,8 +47,8 @@ class StreamingRecognizeClient {
       bool print_transcripts, int32_t chunk_duration_ms, bool interim_results,
       std::string output_filename, std::string model_name, bool simulate_realtime,
       bool verbatim_transcripts, const std::string& boosted_phrases_file,
-      float boosted_phrases_score, int32_t set_endpoint_start_history, float endpoint_start_threshold, 
-      int32_t endpoint_reset_history,int32_t endpoint_response_history,float endpoint_stop_threshold);
+      float boosted_phrases_score, int32_t start_history, float start_threshold, 
+      int32_t stop_history, int32_t stop_history_eou, float stop_threshold);
 
   ~StreamingRecognizeClient();
 
@@ -116,9 +116,9 @@ class StreamingRecognizeClient {
   std::vector<std::string> boosted_phrases_;
   float boosted_phrases_score_;
 
-  int32_t endpoint_start_history_;
-  float endpoint_start_threshold_;
-  int32_t endpoint_reset_history_;
-  int32_t endpoint_response_history_;
-  float endpoint_stop_threshold_;
+  int32_t start_history_;
+  float start_threshold_;
+  int32_t stop_history_;
+  int32_t stop_history_eou_;
+  float stop_threshold_;
 };

--- a/riva/clients/asr/streaming_recognize_client.h
+++ b/riva/clients/asr/streaming_recognize_client.h
@@ -59,7 +59,9 @@ class StreamingRecognizeClient {
   float TotalAudioProcessed() { return total_audio_processed_; }
 
   void StartNewStream(std::unique_ptr<Stream> stream);
-
+  
+  void UpdateEndpointingConfig(nr_asr::RecognitionConfig* config);
+  
   void GenerateRequests(std::shared_ptr<ClientCall> call);
 
   int DoStreamingFromFile(

--- a/riva/clients/asr/streaming_recognize_client.h
+++ b/riva/clients/asr/streaming_recognize_client.h
@@ -47,7 +47,8 @@ class StreamingRecognizeClient {
       bool print_transcripts, int32_t chunk_duration_ms, bool interim_results,
       std::string output_filename, std::string model_name, bool simulate_realtime,
       bool verbatim_transcripts, const std::string& boosted_phrases_file,
-      float boosted_phrases_score);
+      float boosted_phrases_score, int32_t set_endpoint_start_history, float endpoint_start_threshold, 
+      int32_t endpoint_reset_history,int32_t endpoint_response_history,float endpoint_stop_threshold);
 
   ~StreamingRecognizeClient();
 
@@ -114,4 +115,10 @@ class StreamingRecognizeClient {
 
   std::vector<std::string> boosted_phrases_;
   float boosted_phrases_score_;
+
+  int32_t endpoint_start_history_;
+  float endpoint_start_threshold_;
+  int32_t endpoint_reset_history_;
+  int32_t endpoint_response_history_;
+  float endpoint_stop_threshold_;
 };

--- a/riva/clients/asr/streaming_recognize_client_test.cc
+++ b/riva/clients/asr/streaming_recognize_client_test.cc
@@ -20,7 +20,7 @@ TEST(StreamingRecognizeClient, num_responses_requests)
 
   StreamingRecognizeClient recognize_client(
       grpc_channel, 1, "en-US", 1, false, false, false, false, false, 800, false, "dummy.txt",
-      "dummy", true, true, "", 10.);
+      "dummy", true, true, "", 10., 10, 0.98, 10, 8, 0.98);
 
   std::shared_ptr<ClientCall> call = std::make_shared<ClientCall>(1, true);
   uint32_t num_sends = 10;


### PR DESCRIPTION
With these changes, clients can now configure end and start of utterance for streaming ASR:
The new parameters introduced are:
           --start_history = int
           --start_threshold = float 
           --stop_history = int
           --stop_history_eou = float
           --stop_threshold = int