### PR TITLE
Exposing the 'stop_historu_eou_th' parameter

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,8 +69,8 @@ grpc_extra_deps()
 
 git_repository(
      name = "nvriva_common",
-     remote = "https://github.com/nvidia-riva/common.git",
-     commit = "9dfc052bba9a0cc2cc4b4f156e0ca8a273e9444e"
+     remote = "https://github.com/sarane22/common.git",
+     commit = "31db08d824d0f4fec0b244235c46e861c16fe5bb"
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -70,7 +70,7 @@ grpc_extra_deps()
 git_repository(
      name = "nvriva_common",
      remote = "https://github.com/sarane22/common.git",
-     commit = "31db08d824d0f4fec0b244235c46e861c16fe5bb"
+     commit = "cc571a0219e9e3936e854bd7254774baf3b9ba08"
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,8 +69,8 @@ grpc_extra_deps()
 
 git_repository(
      name = "nvriva_common",
-     remote = "https://github.com/sarane22/common.git",
-     commit = "cc571a0219e9e3936e854bd7254774baf3b9ba08"
+     remote = "https://github.com/nvidia-riva/common.git",
+     commit = "a5707ad2c4e3bf904905a9c5165fdecf9fab133b"
 )
 
 http_archive(

--- a/riva/clients/asr/BUILD
+++ b/riva/clients/asr/BUILD
@@ -41,6 +41,7 @@ cc_library(
         ":asr_client_helper",
         "@com_github_grpc_grpc//:grpc++",
         "@nvriva_common//riva/proto:riva_grpc_asr",
+        "@glog//:glog",
         "//riva/utils/wav:reader",
     ],
 )

--- a/riva/clients/asr/client_call.cc
+++ b/riva/clients/asr/client_call.cc
@@ -14,7 +14,7 @@ ClientCall::ClientCall(uint32_t corr_id, bool word_time_offsets)
 }
 
 void
-ClientCall::AppendResult(const nr_asr::StreamingRecognitionResult& result)
+ClientCall::AppendResult(const nr_asr::StreamingRecognitionResult& result, bool verbose)
 {
   bool is_final = result.is_final();
   if (latest_result_.final_transcripts.size() < 1) {
@@ -32,6 +32,9 @@ ClientCall::AppendResult(const nr_asr::StreamingRecognitionResult& result)
       latest_result_.final_transcripts[a] += result.alternatives(a).transcript();
       latest_result_.final_scores[a] += result.alternatives(a).confidence();
     }
+    if (verbose){
+      DLOG(INFO) << "Final transcript: " << result.alternatives(0).transcript();
+    }
     if (word_time_offsets_) {
       if (num_alternatives > 0) {
         for (int a = 0; a < num_alternatives; ++a) {
@@ -43,6 +46,9 @@ ClientCall::AppendResult(const nr_asr::StreamingRecognitionResult& result)
     }
   } else {
     if (result.alternatives_size() > 0) {
+      if (verbose && result.stability() == 1){
+        DLOG(INFO) << "Intermediate transcript: " << result.alternatives(0).transcript();
+      }
       latest_result_.partial_transcript += result.alternatives(0).transcript();
       if (word_time_offsets_) {
         for (int w = 0; w < result.alternatives(0).words_size(); ++w) {

--- a/riva/clients/asr/client_call.cc
+++ b/riva/clients/asr/client_call.cc
@@ -14,7 +14,7 @@ ClientCall::ClientCall(uint32_t corr_id, bool word_time_offsets)
 }
 
 void
-ClientCall::AppendResult(const nr_asr::StreamingRecognitionResult& result, bool verbose)
+ClientCall::AppendResult(const nr_asr::StreamingRecognitionResult& result)
 {
   bool is_final = result.is_final();
   if (latest_result_.final_transcripts.size() < 1) {
@@ -32,9 +32,8 @@ ClientCall::AppendResult(const nr_asr::StreamingRecognitionResult& result, bool 
       latest_result_.final_transcripts[a] += result.alternatives(a).transcript();
       latest_result_.final_scores[a] += result.alternatives(a).confidence();
     }
-    if (verbose){
-      DLOG(INFO) << "Final transcript: " << result.alternatives(0).transcript();
-    }
+    VLOG(1) << "Final transcript: " << result.alternatives(0).transcript();
+
     if (word_time_offsets_) {
       if (num_alternatives > 0) {
         for (int a = 0; a < num_alternatives; ++a) {
@@ -46,13 +45,14 @@ ClientCall::AppendResult(const nr_asr::StreamingRecognitionResult& result, bool 
     }
   } else {
     if (result.alternatives_size() > 0) {
-      if (verbose && result.stability() == 1){
-        DLOG(INFO) << "Intermediate transcript: " << result.alternatives(0).transcript();
-      }
-      latest_result_.partial_transcript += result.alternatives(0).transcript();
-      if (word_time_offsets_) {
-        for (int w = 0; w < result.alternatives(0).words_size(); ++w) {
-          latest_result_.partial_time_stamps.emplace_back(result.alternatives(0).words(w));
+      if (result.stability() == 1) {
+        VLOG(1) << "Intermediate transcript: " << result.alternatives(0).transcript();
+      } else {
+        latest_result_.partial_transcript += result.alternatives(0).transcript();
+        if (word_time_offsets_) {
+          for (int w = 0; w < result.alternatives(0).words_size(); ++w) {
+            latest_result_.partial_time_stamps.emplace_back(result.alternatives(0).words(w));
+          }
         }
       }
     }

--- a/riva/clients/asr/client_call.h
+++ b/riva/clients/asr/client_call.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include <grpcpp/grpcpp.h>
 #include <glog/logging.h>
+#include <grpcpp/grpcpp.h>
 #include <strings.h>
 
 #include <atomic>
@@ -38,7 +38,7 @@ class ClientCall {
  public:
   ClientCall(uint32_t _corr_id, bool word_time_offsets);
 
-  void AppendResult(const nr_asr::StreamingRecognitionResult& result, bool verbose=false);
+  void AppendResult(const nr_asr::StreamingRecognitionResult& result);
 
   void PrintResult(bool audio_device, std::ofstream& output_file);
 

--- a/riva/clients/asr/client_call.h
+++ b/riva/clients/asr/client_call.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <grpcpp/grpcpp.h>
+#include <glog/logging.h>
 #include <strings.h>
 
 #include <atomic>
@@ -37,7 +38,7 @@ class ClientCall {
  public:
   ClientCall(uint32_t _corr_id, bool word_time_offsets);
 
-  void AppendResult(const nr_asr::StreamingRecognitionResult& result);
+  void AppendResult(const nr_asr::StreamingRecognitionResult& result, bool verbose=false);
 
   void PrintResult(bool audio_device, std::ofstream& output_file);
 

--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -83,7 +83,7 @@ class RecognizeClient {
       std::string output_filename, std::string model_name, bool ctm, bool verbatim_transcripts,
       const std::string& boosted_phrases_file, float boosted_phrases_score,
       bool speaker_diarization, int32_t start_history, float start_threshold, 
-      int32_t stop_history, int32_t stop_history_eou, float stop_threshold)
+      int32_t stop_history, int32_t stop_history_eou, float stop_threshold, float stop_eou_threshold)
       : stub_(nr_asr::RivaSpeechRecognition::NewStub(channel)), language_code_(language_code),
         max_alternatives_(max_alternatives), profanity_filter_(profanity_filter),
         word_time_offsets_(word_time_offsets), automatic_punctuation_(automatic_punctuation),

--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -265,7 +265,7 @@ class RecognizeClient {
   void UpdateEndpointingConfig(nr_asr::RecognitionConfig* config)
   {
     if (!(start_history_ > 0 || start_threshold_ > 0 || stop_history_ > 0 ||
-          stop_history_eou_ > 0 || stop_threshold_ > 0)) {
+          stop_history_eou_ > 0 || stop_threshold_ > 0 || stop_threshold_eou_ > 0)) {
       return;
     }
 
@@ -280,11 +280,14 @@ class RecognizeClient {
     if (stop_history_ > 0) {
       endpointing_config->set_stop_history(stop_history_);
     }
+    if (stop_threshold_ > 0) {
+      endpointing_config->set_stop_threshold(stop_threshold_);
+    }
     if (stop_history_eou_ > 0) {
       endpointing_config->set_stop_history_eou(stop_history_eou_);
     }
-    if (stop_threshold_ > 0) {
-      endpointing_config->set_stop_threshold(stop_threshold_);
+    if (stop_threshold_eou_ > 0) {
+      endpointing_config->set_stop_threshold_eou(stop_threshold_eou_);
     }
   }
   // Loop while listening for completed responses.

--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -72,6 +72,7 @@ DEFINE_double(start_threshold,-1., "Threshold value to determine at what percent
 DEFINE_int32(stop_history,-1, "Value to detect endpoint and reset decoder");
 DEFINE_int32(stop_history_eou,-1, "Value to detect endpoint and generate an intermediate final transcript");
 DEFINE_double(stop_threshold,-1., "Threshold value to determine when endpoint detected");
+DEFINE_double(stop_eou_threshold,-1., "Threshold value for likelihood of blanks before detecting end of utterance");
 
 class RecognizeClient {
  public:
@@ -440,6 +441,7 @@ main(int argc, char** argv)
   str_usage << "           --stop_history=<int>" << std::endl;
   str_usage << "           --stop_history_eou=<int>" << std::endl;
   str_usage << "           --stop_threshold=<float>" <<  std::endl;
+  str_usage << "           --stop_eou_threshold=<float>" <<  std::endl;
   gflags::SetUsageMessage(str_usage.str());
   gflags::SetVersionString(::riva::utils::kBuildScmRevision);
 
@@ -487,7 +489,7 @@ main(int argc, char** argv)
       FLAGS_model_name, FLAGS_output_ctm, FLAGS_verbatim_transcripts, FLAGS_boosted_words_file,
       (float)FLAGS_boosted_words_score, FLAGS_speaker_diarization, FLAGS_start_history, 
       FLAGS_start_threshold, FLAGS_stop_history, FLAGS_stop_history_eou,
-      FLAGS_stop_threshold);
+      FLAGS_stop_threshold, FLAGS_stop_eou_threshold);
 
   // Preload all wav files, sort by size to reduce tail effects
   std::vector<std::shared_ptr<WaveData>> all_wav;

--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -94,7 +94,7 @@ class RecognizeClient {
         verbatim_transcripts_(verbatim_transcripts), boosted_phrases_score_(boosted_phrases_score), 
         start_history_(start_history), start_threshold_(start_threshold),
         stop_history_(stop_history), stop_history_eou_(stop_history_eou), 
-        stop_threshold_(stop_threshold)
+        stop_threshold_(stop_threshold), stop_eou_threshold_(stop_eou_threshold)
   {
     if (!output_filename.empty()) {
       output_file_.open(output_filename);
@@ -408,6 +408,7 @@ class RecognizeClient {
   int32_t stop_history_;
   int32_t stop_history_eou_;
   float stop_threshold_;
+  float stop_eou_threshold_;
 };
 
 int

--- a/riva/clients/asr/riva_asr_client.cc
+++ b/riva/clients/asr/riva_asr_client.cc
@@ -67,12 +67,17 @@ DEFINE_bool(
     "this is assumed to be true");
 DEFINE_bool(speaker_diarization, false, "Flag that controls if speaker diarization is requested");
 DEFINE_string(metadata, "", "Comma separated key-value pair(s) of metadata to be sent to server");
-DEFINE_int32(start_history,-1, "Value to detect and initiate start of speech utterance");
-DEFINE_double(start_threshold,-1., "Threshold value to determine at what percentage start of speech is initiated");
-DEFINE_int32(stop_history,-1, "Value to detect endpoint and reset decoder");
-DEFINE_int32(stop_history_eou,-1, "Value to detect endpoint and generate an intermediate final transcript");
-DEFINE_double(stop_threshold,-1., "Threshold value to determine when endpoint detected");
-DEFINE_double(stop_eou_threshold,-1., "Threshold value for likelihood of blanks before detecting end of utterance");
+DEFINE_int32(start_history, -1, "Value to detect and initiate start of speech utterance");
+DEFINE_double(
+    start_threshold, -1.,
+    "Threshold value to determine at what percentage start of speech is initiated");
+DEFINE_int32(stop_history, -1, "Value to detect endpoint and reset decoder");
+DEFINE_int32(
+    stop_history_eou, -1, "Value to detect endpoint and generate an intermediate final transcript");
+DEFINE_double(stop_threshold, -1., "Threshold value to determine when endpoint detected");
+DEFINE_double(
+    stop_threshold_eou, -1.,
+    "Threshold value for likelihood of blanks before detecting end of utterance");
 
 class RecognizeClient {
  public:
@@ -82,8 +87,8 @@ class RecognizeClient {
       bool automatic_punctuation, bool separate_recognition_per_channel, bool print_transcripts,
       std::string output_filename, std::string model_name, bool ctm, bool verbatim_transcripts,
       const std::string& boosted_phrases_file, float boosted_phrases_score,
-      bool speaker_diarization, int32_t start_history, float start_threshold, 
-      int32_t stop_history, int32_t stop_history_eou, float stop_threshold, float stop_eou_threshold)
+      bool speaker_diarization, int32_t start_history, float start_threshold, int32_t stop_history,
+      int32_t stop_history_eou, float stop_threshold, float stop_threshold_eou)
       : stub_(nr_asr::RivaSpeechRecognition::NewStub(channel)), language_code_(language_code),
         max_alternatives_(max_alternatives), profanity_filter_(profanity_filter),
         word_time_offsets_(word_time_offsets), automatic_punctuation_(automatic_punctuation),
@@ -91,10 +96,10 @@ class RecognizeClient {
         speaker_diarization_(speaker_diarization), print_transcripts_(print_transcripts),
         done_sending_(false), num_requests_(0), num_responses_(0), num_failed_requests_(0),
         total_audio_processed_(0.), model_name_(model_name), output_filename_(output_filename),
-        verbatim_transcripts_(verbatim_transcripts), boosted_phrases_score_(boosted_phrases_score), 
+        verbatim_transcripts_(verbatim_transcripts), boosted_phrases_score_(boosted_phrases_score),
         start_history_(start_history), start_threshold_(start_threshold),
-        stop_history_(stop_history), stop_history_eou_(stop_history_eou), 
-        stop_threshold_(stop_threshold), stop_eou_threshold_(stop_eou_threshold)
+        stop_history_(stop_history), stop_history_eou_(stop_history_eou),
+        stop_threshold_(stop_threshold), stop_threshold_eou_(stop_threshold_eou)
   {
     if (!output_filename.empty()) {
       output_file_.open(output_filename);
@@ -224,10 +229,10 @@ class RecognizeClient {
     speech_context->set_boost(boosted_phrases_score_);
 
     request.set_audio(&wav->data[0], wav->data.size());
-    
+
     // Set the endpoint parameters
     UpdateEndpointingConfig(config);
-   
+
     {
       std::lock_guard<std::mutex> lock(mutex_);
       curr_tasks_.emplace(stream->corr_id);
@@ -259,26 +264,27 @@ class RecognizeClient {
   // Get a mutable reference to the Endpointing config message
   void UpdateEndpointingConfig(nr_asr::RecognitionConfig* config)
   {
-    if (!(start_history_ > 0 || start_threshold_ > 0 || stop_history_ > 0 || stop_history_eou_ > 0 || stop_threshold_ > 0)) {
-        return; 
+    if (!(start_history_ > 0 || start_threshold_ > 0 || stop_history_ > 0 ||
+          stop_history_eou_ > 0 || stop_threshold_ > 0)) {
+      return;
     }
 
     auto* endpointing_config = config->mutable_endpointing_config();
 
     if (start_history_ > 0) {
-        endpointing_config->set_start_history(start_history_);
+      endpointing_config->set_start_history(start_history_);
     }
     if (start_threshold_ > 0) {
-        endpointing_config->set_start_threshold(start_threshold_);
+      endpointing_config->set_start_threshold(start_threshold_);
     }
     if (stop_history_ > 0) {
-        endpointing_config->set_stop_history(stop_history_);
+      endpointing_config->set_stop_history(stop_history_);
     }
     if (stop_history_eou_ > 0) {
-        endpointing_config->set_stop_history_eou(stop_history_eou_);
+      endpointing_config->set_stop_history_eou(stop_history_eou_);
     }
     if (stop_threshold_ > 0) {
-        endpointing_config->set_stop_threshold(stop_threshold_);
+      endpointing_config->set_stop_threshold(stop_threshold_);
     }
   }
   // Loop while listening for completed responses.
@@ -408,7 +414,7 @@ class RecognizeClient {
   int32_t stop_history_;
   int32_t stop_history_eou_;
   float stop_threshold_;
-  float stop_eou_threshold_;
+  float stop_threshold_eou_;
 };
 
 int
@@ -441,8 +447,8 @@ main(int argc, char** argv)
   str_usage << "           --start_threshold=<float>" << std::endl;
   str_usage << "           --stop_history=<int>" << std::endl;
   str_usage << "           --stop_history_eou=<int>" << std::endl;
-  str_usage << "           --stop_threshold=<float>" <<  std::endl;
-  str_usage << "           --stop_eou_threshold=<float>" <<  std::endl;
+  str_usage << "           --stop_threshold=<float>" << std::endl;
+  str_usage << "           --stop_threshold_eou=<float>" << std::endl;
   gflags::SetUsageMessage(str_usage.str());
   gflags::SetVersionString(::riva::utils::kBuildScmRevision);
 
@@ -462,7 +468,7 @@ main(int argc, char** argv)
     std::cerr << "max_alternatives must be greater than or equal to 1." << std::endl;
     return 1;
   }
-  
+
   bool flag_set = gflags::GetCommandLineFlagInfoOrDie("riva_uri").is_default;
   const char* riva_uri = getenv("RIVA_URI");
 
@@ -488,9 +494,9 @@ main(int argc, char** argv)
       FLAGS_word_time_offsets, FLAGS_automatic_punctuation,
       /* separate_recognition_per_channel*/ false, FLAGS_print_transcripts, FLAGS_output_filename,
       FLAGS_model_name, FLAGS_output_ctm, FLAGS_verbatim_transcripts, FLAGS_boosted_words_file,
-      (float)FLAGS_boosted_words_score, FLAGS_speaker_diarization, FLAGS_start_history, 
-      FLAGS_start_threshold, FLAGS_stop_history, FLAGS_stop_history_eou,
-      FLAGS_stop_threshold, FLAGS_stop_eou_threshold);
+      (float)FLAGS_boosted_words_score, FLAGS_speaker_diarization, FLAGS_start_history,
+      FLAGS_start_threshold, FLAGS_stop_history, FLAGS_stop_history_eou, FLAGS_stop_threshold,
+      FLAGS_stop_threshold_eou);
 
   // Preload all wav files, sort by size to reduce tail effects
   std::vector<std::shared_ptr<WaveData>> all_wav;

--- a/riva/clients/asr/riva_streaming_asr_client.cc
+++ b/riva/clients/asr/riva_streaming_asr_client.cc
@@ -82,6 +82,7 @@ DEFINE_int32(stop_history,-1, "Value to detect endpoint and reset decoder");
 DEFINE_int32(stop_history_eou,-1, "Value to detect endpoint and generate an intermediate final transcript");
 DEFINE_double(stop_threshold,-1., "Threshold value to determine when endpoint detected");
 DEFINE_double(stop_eou_threshold,-1., "Threshold value for likelihood of blanks before detecting end of utterance");
+DEFINE_bool(verbose, false, "Print verbose log for final and intermediate transcript");
 
 void
 signal_handler(int signal_num)
@@ -130,6 +131,7 @@ main(int argc, char** argv)
   str_usage << "           --stop_history_eou=<int>" << std::endl;
   str_usage << "           --stop_threshold=<float>" <<  std::endl;
   str_usage << "           --stop_eou_threshold=<float>" <<  std::endl;
+  str_usage << "           --verbose=<true|false>" <<  std::endl;
   gflags::SetUsageMessage(str_usage.str());
   gflags::SetVersionString(::riva::utils::kBuildScmRevision);
 
@@ -178,7 +180,7 @@ main(int argc, char** argv)
       FLAGS_interim_results, FLAGS_output_filename, FLAGS_model_name, FLAGS_simulate_realtime,
       FLAGS_verbatim_transcripts, FLAGS_boosted_words_file, FLAGS_boosted_words_score, 
       FLAGS_start_history, FLAGS_start_threshold, FLAGS_stop_history, 
-      FLAGS_stop_history_eou, FLAGS_stop_threshold, FLAGS_stop_eou_threshold);
+      FLAGS_stop_history_eou, FLAGS_stop_threshold, FLAGS_stop_eou_threshold, FLAGS_verbose);
 
   if (FLAGS_audio_file.size()) {
     return recognize_client.DoStreamingFromFile(

--- a/riva/clients/asr/riva_streaming_asr_client.cc
+++ b/riva/clients/asr/riva_streaming_asr_client.cc
@@ -76,13 +76,17 @@ DEFINE_bool(
     "Whether to use SSL credentials or not. If ssl_cert is specified, "
     "this is assumed to be true");
 DEFINE_string(metadata, "", "Comma separated key-value pair(s) of metadata to be sent to server");
-DEFINE_int32(start_history,-1, "Value to detect and initiate start of speech utterance");
-DEFINE_double(start_threshold,-1., "Threshold value to determine at what percentage start of speech is initiated");
-DEFINE_int32(stop_history,-1, "Value to detect endpoint and reset decoder");
-DEFINE_int32(stop_history_eou,-1, "Value to detect endpoint and generate an intermediate final transcript");
-DEFINE_double(stop_threshold,-1., "Threshold value to determine when endpoint detected");
-DEFINE_double(stop_eou_threshold,-1., "Threshold value for likelihood of blanks before detecting end of utterance");
-DEFINE_bool(verbose, false, "Print verbose log for final and intermediate transcript");
+DEFINE_int32(start_history, -1, "Value to detect and initiate start of speech utterance");
+DEFINE_double(
+    start_threshold, -1.,
+    "Threshold value to determine at what percentage start of speech is initiated");
+DEFINE_int32(stop_history, -1, "Value to detect endpoint and reset decoder");
+DEFINE_int32(
+    stop_history_eou, -1, "Value to detect endpoint and generate an intermediate final transcript");
+DEFINE_double(stop_threshold, -1., "Threshold value to determine when endpoint detected");
+DEFINE_double(
+    stop_eou_threshold, -1.,
+    "Threshold value for likelihood of blanks before detecting end of utterance");
 
 void
 signal_handler(int signal_num)
@@ -129,9 +133,8 @@ main(int argc, char** argv)
   str_usage << "           --start_threshold=<float>" << std::endl;
   str_usage << "           --stop_history=<int>" << std::endl;
   str_usage << "           --stop_history_eou=<int>" << std::endl;
-  str_usage << "           --stop_threshold=<float>" <<  std::endl;
-  str_usage << "           --stop_eou_threshold=<float>" <<  std::endl;
-  str_usage << "           --verbose=<true|false>" <<  std::endl;
+  str_usage << "           --stop_threshold=<float>" << std::endl;
+  str_usage << "           --stop_eou_threshold=<float>" << std::endl;
   gflags::SetUsageMessage(str_usage.str());
   gflags::SetVersionString(::riva::utils::kBuildScmRevision);
 
@@ -178,9 +181,9 @@ main(int argc, char** argv)
       FLAGS_profanity_filter, FLAGS_word_time_offsets, FLAGS_automatic_punctuation,
       /* separate_recognition_per_channel*/ false, FLAGS_print_transcripts, FLAGS_chunk_duration_ms,
       FLAGS_interim_results, FLAGS_output_filename, FLAGS_model_name, FLAGS_simulate_realtime,
-      FLAGS_verbatim_transcripts, FLAGS_boosted_words_file, FLAGS_boosted_words_score, 
-      FLAGS_start_history, FLAGS_start_threshold, FLAGS_stop_history, 
-      FLAGS_stop_history_eou, FLAGS_stop_threshold, FLAGS_stop_eou_threshold, FLAGS_verbose);
+      FLAGS_verbatim_transcripts, FLAGS_boosted_words_file, FLAGS_boosted_words_score,
+      FLAGS_start_history, FLAGS_start_threshold, FLAGS_stop_history, FLAGS_stop_history_eou,
+      FLAGS_stop_threshold, FLAGS_stop_eou_threshold);
 
   if (FLAGS_audio_file.size()) {
     return recognize_client.DoStreamingFromFile(

--- a/riva/clients/asr/riva_streaming_asr_client.cc
+++ b/riva/clients/asr/riva_streaming_asr_client.cc
@@ -76,14 +76,16 @@ DEFINE_bool(
     "Whether to use SSL credentials or not. If ssl_cert is specified, "
     "this is assumed to be true");
 DEFINE_string(metadata, "", "Comma separated key-value pair(s) of metadata to be sent to server");
-DEFINE_int32(start_history, -1, "Value to detect and initiate start of speech utterance");
+DEFINE_int32(
+    start_history, -1, "Value (in milliseconds) to detect and initiate start of speech utterance");
 DEFINE_double(
     start_threshold, -1.,
     "Threshold value to determine at what percentage start of speech is initiated");
-DEFINE_int32(stop_history, -1, "Value to detect endpoint and reset decoder");
-DEFINE_int32(
-    stop_history_eou, -1, "Value to detect endpoint and generate an intermediate final transcript");
+DEFINE_int32(stop_history, -1, "Value (in milliseconds) to detect endpoint and reset decoder");
 DEFINE_double(stop_threshold, -1., "Threshold value to determine when endpoint detected");
+DEFINE_int32(
+    stop_history_eou, -1,
+    "Value (in milliseconds) to detect endpoint and generate an intermediate final transcript");
 DEFINE_double(
     stop_threshold_eou, -1.,
     "Threshold value for likelihood of blanks before detecting end of utterance");

--- a/riva/clients/asr/riva_streaming_asr_client.cc
+++ b/riva/clients/asr/riva_streaming_asr_client.cc
@@ -85,7 +85,7 @@ DEFINE_int32(
     stop_history_eou, -1, "Value to detect endpoint and generate an intermediate final transcript");
 DEFINE_double(stop_threshold, -1., "Threshold value to determine when endpoint detected");
 DEFINE_double(
-    stop_eou_threshold, -1.,
+    stop_threshold_eou, -1.,
     "Threshold value for likelihood of blanks before detecting end of utterance");
 
 void
@@ -134,7 +134,7 @@ main(int argc, char** argv)
   str_usage << "           --stop_history=<int>" << std::endl;
   str_usage << "           --stop_history_eou=<int>" << std::endl;
   str_usage << "           --stop_threshold=<float>" << std::endl;
-  str_usage << "           --stop_eou_threshold=<float>" << std::endl;
+  str_usage << "           --stop_threshold_eou=<float>" << std::endl;
   gflags::SetUsageMessage(str_usage.str());
   gflags::SetVersionString(::riva::utils::kBuildScmRevision);
 
@@ -183,7 +183,7 @@ main(int argc, char** argv)
       FLAGS_interim_results, FLAGS_output_filename, FLAGS_model_name, FLAGS_simulate_realtime,
       FLAGS_verbatim_transcripts, FLAGS_boosted_words_file, FLAGS_boosted_words_score,
       FLAGS_start_history, FLAGS_start_threshold, FLAGS_stop_history, FLAGS_stop_history_eou,
-      FLAGS_stop_threshold, FLAGS_stop_eou_threshold);
+      FLAGS_stop_threshold, FLAGS_stop_threshold_eou);
 
   if (FLAGS_audio_file.size()) {
     return recognize_client.DoStreamingFromFile(

--- a/riva/clients/asr/riva_streaming_asr_client.cc
+++ b/riva/clients/asr/riva_streaming_asr_client.cc
@@ -81,6 +81,7 @@ DEFINE_double(start_threshold,-1., "Threshold value to determine at what percent
 DEFINE_int32(stop_history,-1, "Value to detect endpoint and reset decoder");
 DEFINE_int32(stop_history_eou,-1, "Value to detect endpoint and generate an intermediate final transcript");
 DEFINE_double(stop_threshold,-1., "Threshold value to determine when endpoint detected");
+DEFINE_double(stop_eou_threshold,-1., "Threshold value for likelihood of blanks before detecting end of utterance");
 
 void
 signal_handler(int signal_num)
@@ -128,6 +129,7 @@ main(int argc, char** argv)
   str_usage << "           --stop_history=<int>" << std::endl;
   str_usage << "           --stop_history_eou=<int>" << std::endl;
   str_usage << "           --stop_threshold=<float>" <<  std::endl;
+  str_usage << "           --stop_eou_threshold=<float>" <<  std::endl;
   gflags::SetUsageMessage(str_usage.str());
   gflags::SetVersionString(::riva::utils::kBuildScmRevision);
 
@@ -176,7 +178,7 @@ main(int argc, char** argv)
       FLAGS_interim_results, FLAGS_output_filename, FLAGS_model_name, FLAGS_simulate_realtime,
       FLAGS_verbatim_transcripts, FLAGS_boosted_words_file, FLAGS_boosted_words_score, 
       FLAGS_start_history, FLAGS_start_threshold, FLAGS_stop_history, 
-      FLAGS_stop_history_eou, FLAGS_stop_threshold);
+      FLAGS_stop_history_eou, FLAGS_stop_threshold, FLAGS_stop_eou_threshold);
 
   if (FLAGS_audio_file.size()) {
     return recognize_client.DoStreamingFromFile(

--- a/riva/clients/asr/streaming_recognize_client.cc
+++ b/riva/clients/asr/streaming_recognize_client.cc
@@ -58,8 +58,8 @@ StreamingRecognizeClient::StreamingRecognizeClient(
     bool print_transcripts, int32_t chunk_duration_ms, bool interim_results,
     std::string output_filename, std::string model_name, bool simulate_realtime,
     bool verbatim_transcripts, const std::string& boosted_phrases_file, float boosted_phrases_score,
-    int32_t start_history, float start_threshold, int32_t stop_history,
-    int32_t stop_history_eou, float stop_threshold, float stop_eou_threshold, bool verbose)
+    int32_t start_history, float start_threshold, int32_t stop_history, int32_t stop_history_eou,
+    float stop_threshold, float stop_eou_threshold)
     : print_latency_stats_(true), stub_(nr_asr::RivaSpeechRecognition::NewStub(channel)),
       language_code_(language_code), max_alternatives_(max_alternatives),
       profanity_filter_(profanity_filter), word_time_offsets_(word_time_offsets),
@@ -69,9 +69,9 @@ StreamingRecognizeClient::StreamingRecognizeClient(
       interim_results_(interim_results), total_audio_processed_(0.), num_streams_started_(0),
       model_name_(model_name), simulate_realtime_(simulate_realtime),
       verbatim_transcripts_(verbatim_transcripts), boosted_phrases_score_(boosted_phrases_score),
-      start_history_(start_history), start_threshold_(start_threshold),
-      stop_history_(stop_history), stop_history_eou_(stop_history_eou),
-      stop_threshold_(stop_threshold), stop_eou_threshold_(stop_eou_threshold), verbose_(verbose)
+      start_history_(start_history), start_threshold_(start_threshold), stop_history_(stop_history),
+      stop_history_eou_(stop_history_eou), stop_threshold_(stop_threshold),
+      stop_eou_threshold_(stop_eou_threshold)
 {
   num_active_streams_.store(0);
   num_streams_finished_.store(0);
@@ -113,30 +113,31 @@ StreamingRecognizeClient::StartNewStream(std::unique_ptr<Stream> stream)
 void
 StreamingRecognizeClient::UpdateEndpointingConfig(nr_asr::RecognitionConfig* config)
 {
-  if (!(start_history_ > 0 || start_threshold_ > 0 || stop_history_ > 0 || stop_history_eou_ > 0 || stop_threshold_ > 0 || stop_eou_threshold_ > 0)) {
-      return; 
+  if (!(start_history_ > 0 || start_threshold_ > 0 || stop_history_ > 0 || stop_history_eou_ > 0 ||
+        stop_threshold_ > 0 || stop_eou_threshold_ > 0)) {
+    return;
   }
   // Set the endpoint parameters
   // Get a mutable reference to the Endpointing config message
   auto* endpointing_config = config->mutable_endpointing_config();
 
   if (start_history_ > 0) {
-      endpointing_config->set_start_history(start_history_);
+    endpointing_config->set_start_history(start_history_);
   }
   if (start_threshold_ > 0) {
-      endpointing_config->set_start_threshold(start_threshold_);
+    endpointing_config->set_start_threshold(start_threshold_);
   }
   if (stop_history_ > 0) {
-      endpointing_config->set_stop_history(stop_history_);
+    endpointing_config->set_stop_history(stop_history_);
   }
   if (stop_history_eou_ > 0) {
-      endpointing_config->set_stop_history_eou(stop_history_eou_);
+    endpointing_config->set_stop_history_eou(stop_history_eou_);
   }
   if (stop_threshold_ > 0) {
-      endpointing_config->set_stop_threshold(stop_threshold_);
+    endpointing_config->set_stop_threshold(stop_threshold_);
   }
   if (stop_eou_threshold_ > 0) {
-      endpointing_config->set_stop_eou_threshold(stop_eou_threshold_);
+    endpointing_config->set_stop_eou_threshold(stop_eou_threshold_);
   }
 }
 
@@ -359,7 +360,7 @@ StreamingRecognizeClient::ReceiveResponses(std::shared_ptr<ClientCall> call, boo
 
       call->latest_result_.audio_processed = result.audio_processed();
       if (print_transcripts_) {
-        call->AppendResult(result, verbose_);
+        call->AppendResult(result);
       }
     }
 

--- a/riva/clients/asr/streaming_recognize_client.cc
+++ b/riva/clients/asr/streaming_recognize_client.cc
@@ -59,7 +59,7 @@ StreamingRecognizeClient::StreamingRecognizeClient(
     std::string output_filename, std::string model_name, bool simulate_realtime,
     bool verbatim_transcripts, const std::string& boosted_phrases_file, float boosted_phrases_score,
     int32_t start_history, float start_threshold, int32_t stop_history,
-    int32_t stop_history_eou, float stop_threshold, float stop_eou_threshold)
+    int32_t stop_history_eou, float stop_threshold, float stop_eou_threshold, bool verbose)
     : print_latency_stats_(true), stub_(nr_asr::RivaSpeechRecognition::NewStub(channel)),
       language_code_(language_code), max_alternatives_(max_alternatives),
       profanity_filter_(profanity_filter), word_time_offsets_(word_time_offsets),
@@ -71,7 +71,7 @@ StreamingRecognizeClient::StreamingRecognizeClient(
       verbatim_transcripts_(verbatim_transcripts), boosted_phrases_score_(boosted_phrases_score),
       start_history_(start_history), start_threshold_(start_threshold),
       stop_history_(stop_history), stop_history_eou_(stop_history_eou),
-      stop_threshold_(stop_threshold), stop_eou_threshold_(stop_eou_threshold)
+      stop_threshold_(stop_threshold), stop_eou_threshold_(stop_eou_threshold), verbose_(verbose)
 {
   num_active_streams_.store(0);
   num_streams_finished_.store(0);
@@ -359,7 +359,7 @@ StreamingRecognizeClient::ReceiveResponses(std::shared_ptr<ClientCall> call, boo
 
       call->latest_result_.audio_processed = result.audio_processed();
       if (print_transcripts_) {
-        call->AppendResult(result);
+        call->AppendResult(result, verbose_);
       }
     }
 

--- a/riva/clients/asr/streaming_recognize_client.cc
+++ b/riva/clients/asr/streaming_recognize_client.cc
@@ -59,7 +59,7 @@ StreamingRecognizeClient::StreamingRecognizeClient(
     std::string output_filename, std::string model_name, bool simulate_realtime,
     bool verbatim_transcripts, const std::string& boosted_phrases_file, float boosted_phrases_score,
     int32_t start_history, float start_threshold, int32_t stop_history, int32_t stop_history_eou,
-    float stop_threshold, float stop_eou_threshold)
+    float stop_threshold, float stop_threshold_eou)
     : print_latency_stats_(true), stub_(nr_asr::RivaSpeechRecognition::NewStub(channel)),
       language_code_(language_code), max_alternatives_(max_alternatives),
       profanity_filter_(profanity_filter), word_time_offsets_(word_time_offsets),
@@ -71,7 +71,7 @@ StreamingRecognizeClient::StreamingRecognizeClient(
       verbatim_transcripts_(verbatim_transcripts), boosted_phrases_score_(boosted_phrases_score),
       start_history_(start_history), start_threshold_(start_threshold), stop_history_(stop_history),
       stop_history_eou_(stop_history_eou), stop_threshold_(stop_threshold),
-      stop_eou_threshold_(stop_eou_threshold)
+      stop_threshold_eou_(stop_threshold_eou)
 {
   num_active_streams_.store(0);
   num_streams_finished_.store(0);
@@ -114,7 +114,7 @@ void
 StreamingRecognizeClient::UpdateEndpointingConfig(nr_asr::RecognitionConfig* config)
 {
   if (!(start_history_ > 0 || start_threshold_ > 0 || stop_history_ > 0 || stop_history_eou_ > 0 ||
-        stop_threshold_ > 0 || stop_eou_threshold_ > 0)) {
+        stop_threshold_ > 0 || stop_threshold_eou_ > 0)) {
     return;
   }
   // Set the endpoint parameters
@@ -136,8 +136,8 @@ StreamingRecognizeClient::UpdateEndpointingConfig(nr_asr::RecognitionConfig* con
   if (stop_threshold_ > 0) {
     endpointing_config->set_stop_threshold(stop_threshold_);
   }
-  if (stop_eou_threshold_ > 0) {
-    endpointing_config->set_stop_eou_threshold(stop_eou_threshold_);
+  if (stop_threshold_eou_ > 0) {
+    endpointing_config->set_stop_threshold_eou(stop_threshold_eou_);
   }
 }
 

--- a/riva/clients/asr/streaming_recognize_client.cc
+++ b/riva/clients/asr/streaming_recognize_client.cc
@@ -58,8 +58,8 @@ StreamingRecognizeClient::StreamingRecognizeClient(
     bool print_transcripts, int32_t chunk_duration_ms, bool interim_results,
     std::string output_filename, std::string model_name, bool simulate_realtime,
     bool verbatim_transcripts, const std::string& boosted_phrases_file, float boosted_phrases_score,
-    int32_t start_history, float start_threshold, int32_t stop_history, 
-    int32_t stop_history_eou, float stop_threshold)
+    int32_t start_history, float start_threshold, int32_t stop_history,
+    int32_t stop_history_eou, float stop_threshold, float stop_eou_threshold)
     : print_latency_stats_(true), stub_(nr_asr::RivaSpeechRecognition::NewStub(channel)),
       language_code_(language_code), max_alternatives_(max_alternatives),
       profanity_filter_(profanity_filter), word_time_offsets_(word_time_offsets),
@@ -70,8 +70,8 @@ StreamingRecognizeClient::StreamingRecognizeClient(
       model_name_(model_name), simulate_realtime_(simulate_realtime),
       verbatim_transcripts_(verbatim_transcripts), boosted_phrases_score_(boosted_phrases_score),
       start_history_(start_history), start_threshold_(start_threshold),
-      stop_history_(stop_history), stop_history_eou_(stop_history), 
-      stop_threshold_(stop_threshold)
+      stop_history_(stop_history), stop_history_eou_(stop_history_eou),
+      stop_threshold_(stop_threshold), stop_eou_threshold_(stop_eou_threshold)
 {
   num_active_streams_.store(0);
   num_streams_finished_.store(0);
@@ -113,7 +113,7 @@ StreamingRecognizeClient::StartNewStream(std::unique_ptr<Stream> stream)
 void
 StreamingRecognizeClient::UpdateEndpointingConfig(nr_asr::RecognitionConfig* config)
 {
-  if (!(start_history_ > 0 || start_threshold_ > 0 || stop_history_ > 0 || stop_history_eou_ > 0 || stop_threshold_ > 0)) {
+  if (!(start_history_ > 0 || start_threshold_ > 0 || stop_history_ > 0 || stop_history_eou_ > 0 || stop_threshold_ > 0 || stop_eou_threshold_ > 0)) {
       return; 
   }
   // Set the endpoint parameters
@@ -134,6 +134,9 @@ StreamingRecognizeClient::UpdateEndpointingConfig(nr_asr::RecognitionConfig* con
   }
   if (stop_threshold_ > 0) {
       endpointing_config->set_stop_threshold(stop_threshold_);
+  }
+  if (stop_eou_threshold_ > 0) {
+      endpointing_config->set_stop_eou_threshold(stop_eou_threshold_);
   }
 }
 

--- a/riva/clients/asr/streaming_recognize_client.h
+++ b/riva/clients/asr/streaming_recognize_client.h
@@ -48,7 +48,7 @@ class StreamingRecognizeClient {
       std::string output_filename, std::string model_name, bool simulate_realtime,
       bool verbatim_transcripts, const std::string& boosted_phrases_file,
       float boosted_phrases_score, int32_t start_history, float start_threshold, 
-      int32_t stop_history, int32_t stop_history_eou, float stop_threshold);
+      int32_t stop_history, int32_t stop_history_eou, float stop_threshold, float stop_eou_threshold);
 
   ~StreamingRecognizeClient();
 
@@ -123,4 +123,5 @@ class StreamingRecognizeClient {
   int32_t stop_history_;
   int32_t stop_history_eou_;
   float stop_threshold_;
+  float stop_eou_threshold_;
 };

--- a/riva/clients/asr/streaming_recognize_client.h
+++ b/riva/clients/asr/streaming_recognize_client.h
@@ -48,7 +48,8 @@ class StreamingRecognizeClient {
       std::string output_filename, std::string model_name, bool simulate_realtime,
       bool verbatim_transcripts, const std::string& boosted_phrases_file,
       float boosted_phrases_score, int32_t start_history, float start_threshold, 
-      int32_t stop_history, int32_t stop_history_eou, float stop_threshold, float stop_eou_threshold);
+      int32_t stop_history, int32_t stop_history_eou, float stop_threshold,
+      float stop_eou_threshold, bool verbose=false);
 
   ~StreamingRecognizeClient();
 
@@ -124,4 +125,5 @@ class StreamingRecognizeClient {
   int32_t stop_history_eou_;
   float stop_threshold_;
   float stop_eou_threshold_;
+  bool verbose_;
 };

--- a/riva/clients/asr/streaming_recognize_client.h
+++ b/riva/clients/asr/streaming_recognize_client.h
@@ -47,9 +47,9 @@ class StreamingRecognizeClient {
       bool print_transcripts, int32_t chunk_duration_ms, bool interim_results,
       std::string output_filename, std::string model_name, bool simulate_realtime,
       bool verbatim_transcripts, const std::string& boosted_phrases_file,
-      float boosted_phrases_score, int32_t start_history, float start_threshold, 
+      float boosted_phrases_score, int32_t start_history, float start_threshold,
       int32_t stop_history, int32_t stop_history_eou, float stop_threshold,
-      float stop_eou_threshold, bool verbose=false);
+      float stop_eou_threshold);
 
   ~StreamingRecognizeClient();
 
@@ -60,9 +60,9 @@ class StreamingRecognizeClient {
   float TotalAudioProcessed() { return total_audio_processed_; }
 
   void StartNewStream(std::unique_ptr<Stream> stream);
-  
+
   void UpdateEndpointingConfig(nr_asr::RecognitionConfig* config);
-  
+
   void GenerateRequests(std::shared_ptr<ClientCall> call);
 
   int DoStreamingFromFile(
@@ -125,5 +125,4 @@ class StreamingRecognizeClient {
   int32_t stop_history_eou_;
   float stop_threshold_;
   float stop_eou_threshold_;
-  bool verbose_;
 };

--- a/riva/clients/asr/streaming_recognize_client.h
+++ b/riva/clients/asr/streaming_recognize_client.h
@@ -49,7 +49,7 @@ class StreamingRecognizeClient {
       bool verbatim_transcripts, const std::string& boosted_phrases_file,
       float boosted_phrases_score, int32_t start_history, float start_threshold,
       int32_t stop_history, int32_t stop_history_eou, float stop_threshold,
-      float stop_eou_threshold);
+      float stop_threshold_eou);
 
   ~StreamingRecognizeClient();
 
@@ -124,5 +124,5 @@ class StreamingRecognizeClient {
   int32_t stop_history_;
   int32_t stop_history_eou_;
   float stop_threshold_;
-  float stop_eou_threshold_;
+  float stop_threshold_eou_;
 };

--- a/riva/clients/asr/streaming_recognize_client_test.cc
+++ b/riva/clients/asr/streaming_recognize_client_test.cc
@@ -20,7 +20,7 @@ TEST(StreamingRecognizeClient, num_responses_requests)
 
   StreamingRecognizeClient recognize_client(
       grpc_channel, 1, "en-US", 1, false, false, false, false, false, 800, false, "dummy.txt",
-      "dummy", true, true, "", 10., 10, 0.98, 10, 8, 0.98);
+      "dummy", true, true, "", 10., 10, 0.98, 10, 8, 0.98, 0.98);
 
   std::shared_ptr<ClientCall> call = std::make_shared<ClientCall>(1, true);
   uint32_t num_sends = 10;

--- a/riva/clients/nmt/streaming_s2t_client.cc
+++ b/riva/clients/nmt/streaming_s2t_client.cc
@@ -104,6 +104,7 @@ StreamingS2TClient::GenerateRequests(std::shared_ptr<S2TClientCall> call)
   while (!done) {
     nr_nmt::StreamingTranslateSpeechToTextRequest request;
     if (first_write) {
+      VLOG(1) << "Setting up s2t config.";
       auto streaming_s2t_config = request.mutable_config();
 
       // set nmt config

--- a/riva/clients/nmt/streaming_s2t_client.cc
+++ b/riva/clients/nmt/streaming_s2t_client.cc
@@ -252,7 +252,7 @@ StreamingS2TClient::PostProcessResults(std::shared_ptr<S2TClientCall> call, bool
     double lat =
         std::chrono::duration<double, std::milli>(call->recv_times[0] - call->send_times.back())
             .count();
-    VLOG(1)<< "Latency:" << lat << std::endl;
+    VLOG(1) << "Latency:" << lat << std::endl;
     latencies_.push_back(lat);
   }
 }
@@ -277,7 +277,7 @@ StreamingS2TClient::ReceiveResponses(std::shared_ptr<S2TClientCall> call, bool a
         std::cout << "ASR started... press `Ctrl-C' to stop recording\n\n";
         gotoxy(0, 5);
       }
-      VLOG(1) << "result: " << result.DebugString();
+      VLOG(1) << "Result: " << result.DebugString();
       std::cout << "translated text: \"" << result.alternatives(0).transcript() << "\""
                 << std::endl;
       result_file << result.alternatives(0).transcript() << std::endl;


### PR DESCRIPTION
With these changes, clients can now configure `stop_eou_threshold` for streaming ASR:
The new parameters introduced are:
`--stop_eou_threshold = float`