### PR TITLE
Performance metric- translations/sec is updated

### DIFF
--- a/riva/clients/nmt/riva_nmt_t2t_client.cc
+++ b/riva/clients/nmt/riva_nmt_t2t_client.cc
@@ -90,13 +90,30 @@ translateBatch(
   }
 }
 
+int countWords(const std::string& text) {
+    int wordCount = 0;
+    bool inside_word = false;
+
+    for (char c : text) {
+        if (std::isspace(c)) {
+            inside_word = false;
+        } else if (!std::ispunct(c)) {
+            if (!inside_word) {
+                wordCount++;
+                inside_word = true;
+            }
+        }
+    }
+
+    return wordCount;
+}
 
 int
 main(int argc, char** argv)
 {
   google::InitGoogleLogging(argv[0]);
   FLAGS_logtostderr = 1;
-
+ 
   std::stringstream str_usage;
   str_usage << "Usage: riva_nmt_t2t_client" << std::endl;
   str_usage << "           --text_file=<filename> " << std::endl;
@@ -125,7 +142,7 @@ main(int argc, char** argv)
   if (argc > 1) {
     std::cout << argc << std::endl;
     std::cout << gflags::ProgramUsage();
-    return 1;
+    // return 1;
   }
 
   if (FLAGS_batch_size <= 0) {
@@ -195,6 +212,7 @@ main(int argc, char** argv)
     std::cout << response.translations(0).text() << std::endl;
     return 0;
   }
+  int total_words = 0;
 
   if (FLAGS_text_file != "") {
     // pull strings into vectors per parallel request
@@ -220,6 +238,8 @@ main(int argc, char** argv)
         batch.clear();
       }
       if (!str.empty()) {
+        
+        total_words += countWords(str);
         batch.push_back(make_pair(count, str));
         count++;
       }
@@ -254,6 +274,7 @@ main(int argc, char** argv)
         workers.push_back(std::thread([&, i]() {
           std::unique_ptr<nr_nmt::RivaTranslation::Stub> nmt2(
               nr_nmt::RivaTranslation::NewStub(grpc_channel));
+
           translateBatch(
               std::move(nmt2), request_queue, FLAGS_target_language_code, FLAGS_source_language_code,
               FLAGS_model_name, mtx, latencies, lmtx, responses.at(i));
@@ -270,13 +291,14 @@ main(int argc, char** argv)
       }
 
     }
+
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<double> total = end - start;
     LOG(INFO) << FLAGS_model_name << "-" << FLAGS_batch_size << "-" << FLAGS_source_language_code
               << "-" << FLAGS_target_language_code << ",count:" << count
               << ",total time: " << total.count()
               << ",requests/second: " << FLAGS_num_iterations * request_count / total.count()
-              << ",translations/second: " << FLAGS_num_iterations * count / total.count();
+              << ",translations/second: " << total_words/total.count();
 
     std::sort(latencies.begin(), latencies.end());
     auto size = latencies.size();

--- a/riva/clients/nmt/riva_nmt_t2t_client.cc
+++ b/riva/clients/nmt/riva_nmt_t2t_client.cc
@@ -142,7 +142,7 @@ main(int argc, char** argv)
   if (argc > 1) {
     std::cout << argc << std::endl;
     std::cout << gflags::ProgramUsage();
-    // return 1;
+    return 1;
   }
 
   if (FLAGS_batch_size <= 0) {


### PR DESCRIPTION
Previously the performance metric (translation/sec) showed displayed the value of number of sentences translated per second. Now, the translation/sec metric is updated to show the value of number of tokens translated per second.