### PR TITLE
riva nmt streaming s2t client update

### DIFF
--- a/riva/clients/nmt/riva_nmt_streaming_s2t_client.cc
+++ b/riva/clients/nmt/riva_nmt_streaming_s2t_client.cc
@@ -81,6 +81,11 @@ signal_handler(int signal_num)
   count++;
 }
 
+void emptyFileBeforeRequest() {
+    std::ofstream result_file(FLAGS_nmt_text_file, std::ios::trunc);
+    result_file.close();
+}
+
 int
 main(int argc, char** argv)
 {
@@ -119,7 +124,7 @@ main(int argc, char** argv)
 
   std::signal(SIGINT, signal_handler);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
-
+  emptyFileBeforeRequest();
   if (argc > 1) {
     std::cout << gflags::ProgramUsage();
     return 1;
@@ -151,7 +156,7 @@ main(int argc, char** argv)
       /* separate_recognition_per_channel*/ false, FLAGS_chunk_duration_ms, FLAGS_simulate_realtime,
       FLAGS_verbatim_transcripts, FLAGS_boosted_words_file, FLAGS_boosted_words_score,
       FLAGS_nmt_text_file);
-
+  
   if (FLAGS_audio_file.size()) {
     return recognize_client.DoStreamingFromFile(
         FLAGS_audio_file, FLAGS_num_iterations, FLAGS_num_parallel_requests);

--- a/riva/clients/nmt/riva_nmt_t2t_client.cc
+++ b/riva/clients/nmt/riva_nmt_t2t_client.cc
@@ -90,13 +90,30 @@ translateBatch(
   }
 }
 
+int countWords(const std::string& text) {
+    int wordCount = 0;
+    bool inside_word = false;
+
+    for (char c : text) {
+        if (std::isspace(c)) {
+            inside_word = false;
+        } else if (!std::ispunct(c)) {
+            if (!inside_word) {
+                wordCount++;
+                inside_word = true;
+            }
+        }
+    }
+
+    return wordCount;
+}
 
 int
 main(int argc, char** argv)
 {
   google::InitGoogleLogging(argv[0]);
   FLAGS_logtostderr = 1;
-
+ 
   std::stringstream str_usage;
   str_usage << "Usage: riva_nmt_t2t_client" << std::endl;
   str_usage << "           --text_file=<filename> " << std::endl;
@@ -125,7 +142,7 @@ main(int argc, char** argv)
   if (argc > 1) {
     std::cout << argc << std::endl;
     std::cout << gflags::ProgramUsage();
-    return 1;
+    // return 1;
   }
 
   if (FLAGS_batch_size <= 0) {
@@ -195,6 +212,7 @@ main(int argc, char** argv)
     std::cout << response.translations(0).text() << std::endl;
     return 0;
   }
+  int total_words = 0;
 
   if (FLAGS_text_file != "") {
     // pull strings into vectors per parallel request
@@ -220,6 +238,8 @@ main(int argc, char** argv)
         batch.clear();
       }
       if (!str.empty()) {
+        
+        total_words += countWords(str);
         batch.push_back(make_pair(count, str));
         count++;
       }
@@ -254,6 +274,7 @@ main(int argc, char** argv)
         workers.push_back(std::thread([&, i]() {
           std::unique_ptr<nr_nmt::RivaTranslation::Stub> nmt2(
               nr_nmt::RivaTranslation::NewStub(grpc_channel));
+
           translateBatch(
               std::move(nmt2), request_queue, FLAGS_target_language_code, FLAGS_source_language_code,
               FLAGS_model_name, mtx, latencies, lmtx, responses.at(i));
@@ -270,13 +291,14 @@ main(int argc, char** argv)
       }
 
     }
+
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<double> total = end - start;
     LOG(INFO) << FLAGS_model_name << "-" << FLAGS_batch_size << "-" << FLAGS_source_language_code
               << "-" << FLAGS_target_language_code << ",count:" << count
               << ",total time: " << total.count()
               << ",requests/second: " << FLAGS_num_iterations * request_count / total.count()
-              << ",translations/second: " << FLAGS_num_iterations * count / total.count();
+              << ",translations/second: " << total_words/total.count();
 
     std::sort(latencies.begin(), latencies.end());
     auto size = latencies.size();

--- a/riva/clients/nmt/riva_nmt_t2t_client.cc
+++ b/riva/clients/nmt/riva_nmt_t2t_client.cc
@@ -142,7 +142,7 @@ main(int argc, char** argv)
   if (argc > 1) {
     std::cout << argc << std::endl;
     std::cout << gflags::ProgramUsage();
-    // return 1;
+    return 1;
   }
 
   if (FLAGS_batch_size <= 0) {

--- a/riva/clients/nmt/riva_nmt_t2t_client.cc
+++ b/riva/clients/nmt/riva_nmt_t2t_client.cc
@@ -90,31 +90,13 @@ translateBatch(
   }
 }
 
-int countWords(const std::string& text) {
-  
-    int wordCount = 0;
-    bool inside_word = false;
-
-    for (char c : text) {
-        if (std::isspace(c)) {
-            inside_word = false;
-        } else if (!std::ispunct(c)) {
-            if (!inside_word) {
-                wordCount++;
-                inside_word = true;
-            }
-        }
-    }
-
-    return wordCount;
-}
 
 int
 main(int argc, char** argv)
 {
   google::InitGoogleLogging(argv[0]);
   FLAGS_logtostderr = 1;
- 
+
   std::stringstream str_usage;
   str_usage << "Usage: riva_nmt_t2t_client" << std::endl;
   str_usage << "           --text_file=<filename> " << std::endl;
@@ -213,7 +195,6 @@ main(int argc, char** argv)
     std::cout << response.translations(0).text() << std::endl;
     return 0;
   }
-  int total_words = 0;
 
   if (FLAGS_text_file != "") {
     // pull strings into vectors per parallel request
@@ -239,7 +220,6 @@ main(int argc, char** argv)
         batch.clear();
       }
       if (!str.empty()) {
-        total_words += countWords(str);
         batch.push_back(make_pair(count, str));
         count++;
       }
@@ -275,7 +255,6 @@ main(int argc, char** argv)
         workers.push_back(std::thread([&, i]() {
           std::unique_ptr<nr_nmt::RivaTranslation::Stub> nmt2(
               nr_nmt::RivaTranslation::NewStub(grpc_channel));
-
           translateBatch(
               std::move(nmt2), request_queue, FLAGS_target_language_code,
               FLAGS_source_language_code, FLAGS_model_name, mtx, latencies, lmtx, responses.at(i));
@@ -291,14 +270,13 @@ main(int argc, char** argv)
           }
       }
     }
-
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<double> total = end - start;
     LOG(INFO) << FLAGS_model_name << "-" << FLAGS_batch_size << "-" << FLAGS_source_language_code
               << "-" << FLAGS_target_language_code << ",count:" << count
               << ",total time: " << total.count()
               << ",requests/second: " << FLAGS_num_iterations * request_count / total.count()
-              << ",translations/second: " << total_words/total.count();
+              << ",translations/second: " << FLAGS_num_iterations * count / total.count();
 
     std::sort(latencies.begin(), latencies.end());
     auto size = latencies.size();

--- a/riva/clients/nmt/riva_nmt_t2t_client.cc
+++ b/riva/clients/nmt/riva_nmt_t2t_client.cc
@@ -91,6 +91,7 @@ translateBatch(
 }
 
 int countWords(const std::string& text) {
+  
     int wordCount = 0;
     bool inside_word = false;
 

--- a/riva/clients/nmt/riva_nmt_t2t_client.cc
+++ b/riva/clients/nmt/riva_nmt_t2t_client.cc
@@ -223,6 +223,7 @@ main(int argc, char** argv)
     // std::vector<std::vector<std::vector<std::string>>> inputs;
 
     std::string str;
+    int count = 0;
     std::vector<std::pair<int, std::string>> batch;
     std::vector<std::vector<std::pair<int, std::string>>> all_requests;
     std::ifstream nmt_file(FLAGS_text_file);

--- a/riva/clients/nmt/riva_nmt_t2t_client.cc
+++ b/riva/clients/nmt/riva_nmt_t2t_client.cc
@@ -223,7 +223,6 @@ main(int argc, char** argv)
     // std::vector<std::vector<std::vector<std::string>>> inputs;
 
     std::string str;
-    int count = 0;
     std::vector<std::pair<int, std::string>> batch;
     std::vector<std::vector<std::pair<int, std::string>>> all_requests;
     std::ifstream nmt_file(FLAGS_text_file);
@@ -238,7 +237,6 @@ main(int argc, char** argv)
         batch.clear();
       }
       if (!str.empty()) {
-        
         total_words += countWords(str);
         batch.push_back(make_pair(count, str));
         count++;

--- a/riva/clients/nmt/streaming_s2t_client.cc
+++ b/riva/clients/nmt/streaming_s2t_client.cc
@@ -271,17 +271,27 @@ StreamingS2TClient::ReceiveResponses(std::shared_ptr<S2TClientCall> call, bool a
 
   while (call->streamer->Read(&call->response)) {  // Returns false when no more to read.
     call->recv_times.push_back(std::chrono::steady_clock::now());
+
+    call->latest_result_.partial_transcript = "";
+    call->latest_result_.partial_time_stamps.clear();
+
+    bool is_final = false;
     for (int r = 0; r < call->response.results_size(); ++r) {
       const auto& result = call->response.results(r);
-
+      if (result.is_final()) {
+        is_final = true;
+      }
       if (audio_device) {
         clear_screen();
         std::cout << "ASR started... press `Ctrl-C' to stop recording\n\n";
         gotoxy(0, 5);
       }
       VLOG(1) << "Result: " << result.DebugString();
+      call->latest_result_.audio_processed = result.audio_processed();
+      call->AppendResult(result);
     }
   }
+
   grpc::Status status = call->streamer->Finish();
   if (!status.ok()) {
     // Report the RPC failure.

--- a/riva/clients/nmt/streaming_s2t_client.cc
+++ b/riva/clients/nmt/streaming_s2t_client.cc
@@ -78,6 +78,7 @@ StreamingS2TClient::~StreamingS2TClient() {}
 void
 StreamingS2TClient::StartNewStream(std::unique_ptr<Stream> stream, std::string& audio_file)
 {
+  std::cout << "starting a new stream!" << std::endl;
   std::shared_ptr<S2TClientCall> call = std::make_shared<S2TClientCall>(stream->corr_id, false);
   call->streamer = stub_->StreamingTranslateSpeechToText(&call->context);
   call->stream = std::move(stream);

--- a/riva/clients/nmt/streaming_s2t_client.cc
+++ b/riva/clients/nmt/streaming_s2t_client.cc
@@ -282,7 +282,6 @@ StreamingS2TClient::ReceiveResponses(std::shared_ptr<S2TClientCall> call, bool a
       VLOG(1) << "Result: " << result.DebugString();
     }
   }
-  PostProcessResults(call, audio_device);
   grpc::Status status = call->streamer->Finish();
   if (!status.ok()) {
     // Report the RPC failure.

--- a/riva/clients/nmt/streaming_s2t_client.h
+++ b/riva/clients/nmt/streaming_s2t_client.h
@@ -62,7 +62,7 @@ class StreamingS2TClient {
 
   float TotalAudioProcessed() { return total_audio_processed_; }
 
-  void StartNewStream(std::unique_ptr<Stream> stream);
+  void StartNewStream(std::unique_ptr<Stream> stream, std::string& audio_file);
 
   void GenerateRequests(std::shared_ptr<S2TClientCall> call);
 
@@ -71,7 +71,7 @@ class StreamingS2TClient {
 
   void PostProcessResults(std::shared_ptr<S2TClientCall> call, bool audio_device);
 
-  void ReceiveResponses(std::shared_ptr<S2TClientCall> call, bool audio_device);
+  void ReceiveResponses(std::shared_ptr<S2TClientCall> call, bool audio_device, std::string& audio_file);
 
   int DoStreamingFromMicrophone(const std::string& audio_device, bool& request_exit);
 

--- a/riva/clients/nmt/streaming_s2t_client.h
+++ b/riva/clients/nmt/streaming_s2t_client.h
@@ -49,10 +49,10 @@ class StreamingS2TClient {
   StreamingS2TClient(
       std::shared_ptr<grpc::Channel> channel, int32_t num_parallel_requests,
       const std::string& source_language_code, const std::string& target_language_code,
-      const std::string& dnt_words_file, bool profanity_filter, bool automatic_punctuation,
-      bool separate_recognition_per_channel, int32_t chunk_duration_ms, bool simulate_realtime,
-      bool verbatim_transcripts, const std::string& boosted_phrases_file,
-      float boosted_phrases_score, const std::string& nmt_text_file);
+      bool profanity_filter, bool automatic_punctuation, bool separate_recognition_per_channel,
+      int32_t chunk_duration_ms, bool simulate_realtime, bool verbatim_transcripts,
+      const std::string& boosted_phrases_file, float boosted_phrases_score,
+      const std::string& nmt_text_file);
 
   ~StreamingS2TClient();
 
@@ -62,7 +62,7 @@ class StreamingS2TClient {
 
   float TotalAudioProcessed() { return total_audio_processed_; }
 
-  void StartNewStream(std::unique_ptr<Stream> stream, std::string& audio_file);
+  void StartNewStream(std::unique_ptr<Stream> stream);
 
   void GenerateRequests(std::shared_ptr<S2TClientCall> call);
 
@@ -71,7 +71,7 @@ class StreamingS2TClient {
 
   void PostProcessResults(std::shared_ptr<S2TClientCall> call, bool audio_device);
 
-  void ReceiveResponses(std::shared_ptr<S2TClientCall> call, bool audio_device, std::string& audio_file);
+  void ReceiveResponses(std::shared_ptr<S2TClientCall> call, bool audio_device);
 
   int DoStreamingFromMicrophone(const std::string& audio_device, bool& request_exit);
 
@@ -89,7 +89,6 @@ class StreamingS2TClient {
 
   std::string source_language_code_;
   std::string target_language_code_;
-  std::vector<std::string> dnt_phrases_;
   bool profanity_filter_;
   int32_t channels_;
   bool automatic_punctuation_;


### PR DESCRIPTION
Previously, when processing a folder of audio files using riva nmt streaming s2t client, the output in output.txt is overwritten with each new file processed. This results in only the last audio file's output being retained in the file.

So now the client is updated so that the files are not overwritten but appended and the output will now be shown in json format in the output file