### PR TITLE
Enable Speaker Diarization for Riva Streaming ASR Client

### DIFF
--- a/riva/clients/asr/client_call.h
+++ b/riva/clients/asr/client_call.h
@@ -36,7 +36,7 @@ namespace nr_asr = nvidia::riva::asr;
 
 class ClientCall {
  public:
-  ClientCall(uint32_t _corr_id, bool word_time_offsets);
+  ClientCall(uint32_t _corr_id, bool word_time_offsets, bool speaker_diarization);
   ~ClientCall();
 
   void AppendResult(const nr_asr::StreamingRecognitionResult& result);
@@ -60,6 +60,7 @@ class ClientCall {
 
   uint32_t corr_id_;
   bool word_time_offsets_;
+  bool speaker_diarization_;
 
   Results latest_result_;
 

--- a/riva/clients/asr/riva_streaming_asr_client.cc
+++ b/riva/clients/asr/riva_streaming_asr_client.cc
@@ -96,6 +96,9 @@ DEFINE_string(
 DEFINE_bool(
     speaker_diarization, false, 
     "Flag that controls if speaker diarization is requested");
+DEFINE_int32(
+    diarization_max_speakers, 4,
+    "Max number of speakers to detect when performing speaker diarization. Default is 4 (Max)");
 
 void
 signal_handler(int signal_num)
@@ -148,6 +151,7 @@ main(int argc, char** argv)
   str_usage << "           --stop_threshold_eou=<float>" << std::endl;
   str_usage << "           --custom_configuration=<key:value,key:value,...>" << std::endl;
   str_usage << "           --speaker_diarization=<true|false>" << std::endl;
+  str_usage << "           --diarization_max_speakers=<int>" << std::endl;
   gflags::SetUsageMessage(str_usage.str());
   gflags::SetVersionString(::riva::utils::kBuildScmRevision);
 
@@ -214,7 +218,8 @@ main(int argc, char** argv)
       FLAGS_interim_results, FLAGS_output_filename, FLAGS_model_name, FLAGS_simulate_realtime,
       FLAGS_verbatim_transcripts, FLAGS_boosted_words_file, FLAGS_boosted_words_score,
       FLAGS_start_history, FLAGS_start_threshold, FLAGS_stop_history, FLAGS_stop_history_eou,
-      FLAGS_stop_threshold, FLAGS_stop_threshold_eou, FLAGS_custom_configuration, FLAGS_speaker_diarization);
+      FLAGS_stop_threshold, FLAGS_stop_threshold_eou, FLAGS_custom_configuration, FLAGS_speaker_diarization,
+      FLAGS_diarization_max_speakers);
 
   if (FLAGS_audio_file.size()) {
     return recognize_client.DoStreamingFromFile(

--- a/riva/clients/asr/riva_streaming_asr_client.cc
+++ b/riva/clients/asr/riva_streaming_asr_client.cc
@@ -93,6 +93,9 @@ DEFINE_double(
 DEFINE_string(
     custom_configuration, "",
     "Custom configurations to be sent to the server as key value pairs <key:value,key:value,...>");
+DEFINE_bool(
+    speaker_diarization, false, 
+    "Flag that controls if speaker diarization is requested");
 
 void
 signal_handler(int signal_num)
@@ -144,6 +147,7 @@ main(int argc, char** argv)
   str_usage << "           --stop_threshold=<float>" << std::endl;
   str_usage << "           --stop_threshold_eou=<float>" << std::endl;
   str_usage << "           --custom_configuration=<key:value,key:value,...>" << std::endl;
+  str_usage << "           --speaker_diarization=<true|false>" << std::endl;
   gflags::SetUsageMessage(str_usage.str());
   gflags::SetVersionString(::riva::utils::kBuildScmRevision);
 
@@ -210,7 +214,7 @@ main(int argc, char** argv)
       FLAGS_interim_results, FLAGS_output_filename, FLAGS_model_name, FLAGS_simulate_realtime,
       FLAGS_verbatim_transcripts, FLAGS_boosted_words_file, FLAGS_boosted_words_score,
       FLAGS_start_history, FLAGS_start_threshold, FLAGS_stop_history, FLAGS_stop_history_eou,
-      FLAGS_stop_threshold, FLAGS_stop_threshold_eou, FLAGS_custom_configuration);
+      FLAGS_stop_threshold, FLAGS_stop_threshold_eou, FLAGS_custom_configuration, FLAGS_speaker_diarization);
 
   if (FLAGS_audio_file.size()) {
     return recognize_client.DoStreamingFromFile(

--- a/riva/clients/asr/streaming_recognize_client.cc
+++ b/riva/clients/asr/streaming_recognize_client.cc
@@ -60,7 +60,7 @@ StreamingRecognizeClient::StreamingRecognizeClient(
     bool verbatim_transcripts, const std::string& boosted_phrases_file, float boosted_phrases_score,
     int32_t start_history, float start_threshold, int32_t stop_history, int32_t stop_history_eou,
     float stop_threshold, float stop_threshold_eou, std::string custom_configuration,
-    bool speaker_diarization)
+    bool speaker_diarization, int32_t diarization_max_speakers)
     : print_latency_stats_(true), stub_(nr_asr::RivaSpeechRecognition::NewStub(channel)),
       language_code_(language_code), max_alternatives_(max_alternatives),
       profanity_filter_(profanity_filter), word_time_offsets_(word_time_offsets),
@@ -73,7 +73,7 @@ StreamingRecognizeClient::StreamingRecognizeClient(
       start_history_(start_history), start_threshold_(start_threshold), stop_history_(stop_history),
       stop_history_eou_(stop_history_eou), stop_threshold_(stop_threshold),
       stop_threshold_eou_(stop_threshold_eou), custom_configuration_(custom_configuration),
-      speaker_diarization_(speaker_diarization)
+      speaker_diarization_(speaker_diarization), diarization_max_speakers_(diarization_max_speakers)
 {
   num_active_streams_.store(0);
   num_streams_finished_.store(0);
@@ -144,6 +144,14 @@ StreamingRecognizeClient::UpdateEndpointingConfig(nr_asr::RecognitionConfig* con
 }
 
 void
+StreamingRecognizeClient::UpdateSpeakerDiarizationConfig(nr_asr::RecognitionConfig* config)
+{
+  auto speaker_diarization_config = config->mutable_diarization_config();
+  speaker_diarization_config->set_enable_speaker_diarization(speaker_diarization_);
+  speaker_diarization_config->set_max_speaker_count(diarization_max_speakers_);
+}
+
+void
 StreamingRecognizeClient::GenerateRequests(std::shared_ptr<ClientCall> call)
 {
   float audio_processed = 0.;
@@ -183,6 +191,9 @@ StreamingRecognizeClient::GenerateRequests(std::shared_ptr<ClientCall> call)
 
       // Set the endpoint parameters
       UpdateEndpointingConfig(config);
+
+      // Set the speaker diarization parameters
+      UpdateSpeakerDiarizationConfig(config);
 
       call->streamer->Write(request);
       first_write = false;

--- a/riva/clients/asr/streaming_recognize_client.cc
+++ b/riva/clients/asr/streaming_recognize_client.cc
@@ -59,7 +59,8 @@ StreamingRecognizeClient::StreamingRecognizeClient(
     std::string output_filename, std::string model_name, bool simulate_realtime,
     bool verbatim_transcripts, const std::string& boosted_phrases_file, float boosted_phrases_score,
     int32_t start_history, float start_threshold, int32_t stop_history, int32_t stop_history_eou,
-    float stop_threshold, float stop_threshold_eou, std::string custom_configuration)
+    float stop_threshold, float stop_threshold_eou, std::string custom_configuration,
+    bool speaker_diarization)
     : print_latency_stats_(true), stub_(nr_asr::RivaSpeechRecognition::NewStub(channel)),
       language_code_(language_code), max_alternatives_(max_alternatives),
       profanity_filter_(profanity_filter), word_time_offsets_(word_time_offsets),
@@ -71,7 +72,8 @@ StreamingRecognizeClient::StreamingRecognizeClient(
       verbatim_transcripts_(verbatim_transcripts), boosted_phrases_score_(boosted_phrases_score),
       start_history_(start_history), start_threshold_(start_threshold), stop_history_(stop_history),
       stop_history_eou_(stop_history_eou), stop_threshold_(stop_threshold),
-      stop_threshold_eou_(stop_threshold_eou), custom_configuration_(custom_configuration)
+      stop_threshold_eou_(stop_threshold_eou), custom_configuration_(custom_configuration),
+      speaker_diarization_(speaker_diarization)
 {
   num_active_streams_.store(0);
   num_streams_finished_.store(0);
@@ -95,7 +97,7 @@ void
 StreamingRecognizeClient::StartNewStream(std::unique_ptr<Stream> stream)
 {
   std::shared_ptr<ClientCall> call =
-      std::make_shared<ClientCall>(stream->corr_id, word_time_offsets_);
+      std::make_shared<ClientCall>(stream->corr_id, word_time_offsets_, speaker_diarization_);
   call->streamer = stub_->StreamingRecognize(&call->context);
   call->stream = std::move(stream);
 
@@ -407,7 +409,7 @@ StreamingRecognizeClient::DoStreamingFromMicrophone(
   }
   std::cout << "Using device:" << audio_device << std::endl;
 
-  std::shared_ptr<ClientCall> call = std::make_shared<ClientCall>(1, word_time_offsets_);
+  std::shared_ptr<ClientCall> call = std::make_shared<ClientCall>(1, word_time_offsets_, speaker_diarization_);
   call->streamer = stub_->StreamingRecognize(&call->context);
 
   // Send first request

--- a/riva/clients/asr/streaming_recognize_client.h
+++ b/riva/clients/asr/streaming_recognize_client.h
@@ -49,7 +49,8 @@ class StreamingRecognizeClient {
       bool verbatim_transcripts, const std::string& boosted_phrases_file,
       float boosted_phrases_score, int32_t start_history, float start_threshold,
       int32_t stop_history, int32_t stop_history_eou, float stop_threshold,
-      float stop_threshold_eou, std::string custom_configuration);
+      float stop_threshold_eou, std::string custom_configuration,
+      bool speaker_diarization);
 
   ~StreamingRecognizeClient();
 
@@ -126,4 +127,5 @@ class StreamingRecognizeClient {
   float stop_threshold_;
   float stop_threshold_eou_;
   std::string custom_configuration_;
+  bool speaker_diarization_;
 };

--- a/riva/clients/asr/streaming_recognize_client.h
+++ b/riva/clients/asr/streaming_recognize_client.h
@@ -50,7 +50,7 @@ class StreamingRecognizeClient {
       float boosted_phrases_score, int32_t start_history, float start_threshold,
       int32_t stop_history, int32_t stop_history_eou, float stop_threshold,
       float stop_threshold_eou, std::string custom_configuration,
-      bool speaker_diarization);
+      bool speaker_diarization, int32_t diarization_max_speakers);
 
   ~StreamingRecognizeClient();
 
@@ -63,6 +63,8 @@ class StreamingRecognizeClient {
   void StartNewStream(std::unique_ptr<Stream> stream);
 
   void UpdateEndpointingConfig(nr_asr::RecognitionConfig* config);
+
+  void UpdateSpeakerDiarizationConfig(nr_asr::RecognitionConfig* config);
 
   void GenerateRequests(std::shared_ptr<ClientCall> call);
 
@@ -128,4 +130,5 @@ class StreamingRecognizeClient {
   float stop_threshold_eou_;
   std::string custom_configuration_;
   bool speaker_diarization_;
+  int32_t diarization_max_speakers_;
 };

--- a/riva/clients/asr/streaming_recognize_client_test.cc
+++ b/riva/clients/asr/streaming_recognize_client_test.cc
@@ -20,9 +20,9 @@ TEST(StreamingRecognizeClient, num_responses_requests)
 
   StreamingRecognizeClient recognize_client(
       grpc_channel, 1, "en-US", 1, false, false, false, false, false, 800, false, "dummy.txt",
-      "dummy", true, true, "", 10., 10, 0.98, 10, 8, 0.98, 0.98, "test_key:test_value");
+      "dummy", true, true, "", 10., 10, 0.98, 10, 8, 0.98, 0.98, "test_key:test_value", false);
 
-  std::shared_ptr<ClientCall> call = std::make_shared<ClientCall>(1, true);
+  std::shared_ptr<ClientCall> call = std::make_shared<ClientCall>(1, true, false);
   uint32_t num_sends = 10;
   for (uint32_t send_cnt = 0; send_cnt < num_sends; send_cnt++) {
     call->recv_times.push_back(current_time);

--- a/riva/clients/asr/streaming_recognize_client_test.cc
+++ b/riva/clients/asr/streaming_recognize_client_test.cc
@@ -20,7 +20,7 @@ TEST(StreamingRecognizeClient, num_responses_requests)
 
   StreamingRecognizeClient recognize_client(
       grpc_channel, 1, "en-US", 1, false, false, false, false, false, 800, false, "dummy.txt",
-      "dummy", true, true, "", 10., 10, 0.98, 10, 8, 0.98, 0.98, "test_key:test_value", false);
+      "dummy", true, true, "", 10., 10, 0.98, 10, 8, 0.98, 0.98, "test_key:test_value", false, 4);
 
   std::shared_ptr<ClientCall> call = std::make_shared<ClientCall>(1, true, false);
   uint32_t num_sends = 10;


### PR DESCRIPTION
- Adds the option `--speaker_diarization=<true|false>` to `riva_streaming_asr_client`
- Prints the Speaker ID along with word timestamps for final transcripts